### PR TITLE
refactor: return ORM models from services, move serialization to routes, convert deps to callable classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,412 +1,74 @@
 # EasyInventory API
 
-FastAPI backend for the EasyInventory inventory management platform.
+FastAPI backend for the EasyInventory inventory management platform — a multi-tenant, role-based inventory system with AWS Cognito authentication.
 
-## Prerequisites
+## Tech Stack
 
-- [Git](https://git-scm.com/downloads) installed
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running
-- [Python 3.11+](https://www.python.org/downloads/) (for local dev without Docker)
-
-## Quick Start (Docker — Recommended)
-
-```bash
-# 1. Clone the repository
-git clone https://github.com/your-org/easyinventory-api.git
-cd easyinventory-api
-
-# 2. Create your environment file from the example
-cp .env.example .env
-
-# 3. Build and start all services (API + Postgres)
-docker compose up --build
-
-# 4. In a separate terminal, run database migrations
-docker compose exec api alembic upgrade head
-
-# 5. Verify everything is working
-curl http://localhost:8000/health
-# → {"status": "healthy", "service": "easyinventory-api"}
-```
-
-- **API:** http://localhost:8000
-- **Swagger Docs:** http://localhost:8000/docs
-- **ReDoc:** http://localhost:8000/redoc
-
-## Health Check
-
-```
-GET http://localhost:8000/health
-→ {"status": "healthy", "service": "easyinventory-api"}
-```
-
-## Development Commands
-
-| Command              | What it does                              |
-|----------------------|-------------------------------------------|
-| `make run`           | Start the app with Docker                 |
-| `make build`         | Rebuild and start                         |
-| `make test`          | Run existing test suite (mocked DB)       |
-| `make test-unit`     | Run unit tests only                       |
-| `make test-functional` | Run functional tests only               |
-| `make test-db`       | Start a local test Postgres on port 5433  |
-| `make test-db-stop`  | Stop the local test Postgres              |
-| `make test-v2`       | Run testsv2 suite (real DB, requires test-db) |
-| `make lint`          | Check formatting (black) + types (mypy)   |
-| `make format-fix`    | Auto-fix formatting with black            |
-| `make typecheck`     | Run mypy type checks                      |
-
-## Database
-
-| Command | What it does |
+| Component | Technology |
 |---|---|
-| `make migrate` | Run all pending migrations |
-| `make migrate-generate msg="description"` | Generate a new migration |
-| `make migrate-down` | Rollback last migration |
-| `make db-shell` | Open psql shell |
+| **Framework** | FastAPI (Python 3.11+) |
+| **Database** | PostgreSQL 16 |
+| **ORM** | SQLAlchemy 2.0 (async) + asyncpg |
+| **Migrations** | Alembic |
+| **Auth** | AWS Cognito (JWT) |
+| **Validation** | Pydantic v2 |
+| **Containers** | Docker / Docker Compose |
+| **Reverse Proxy** | Caddy (auto-HTTPS) |
+| **Prod Server** | Gunicorn + Uvicorn workers |
+| **Code Quality** | Black (formatter) + mypy (type checker) |
+| **Testing** | pytest + httpx (mocked DB) and pytest + real Postgres (transaction rollback) |
 
-**Important:** Always run database commands through Docker, not locally:
-
-
-## Authentication (Cognito)
- 
-This app uses AWS Cognito for authentication. See
-[docs/cognito-setup.md](docs/cognito-setup.md) for the full setup guide.
- 
-Required `.env` variables:
- 
-    COGNITO_REGION=us-east-1
-    COGNITO_USER_POOL_ID=<your pool id>
-    COGNITO_APP_CLIENT_ID=<your client id>
- 
-The app fetches Cognito's public keys (JWKS) on first token
-verification and caches them for the process lifetime.
-
-## Organization Management
-
-> TODO roadmap item: [Multi-Organization Support User Story](docs/multi-org-support-user-story.md)
-
-| Method | Endpoint | Role Required | Description |
-|---|---|---|---|
-| GET | /api/orgs/members | Any org member | List all members |
-| POST | /api/orgs/invite | ORG_OWNER, ORG_ADMIN | Invite by email |
-| PATCH | /api/orgs/members/{id}/role | ORG_OWNER, ORG_ADMIN | Change role |
-| PATCH | /api/orgs/members/{id}/deactivate | ORG_OWNER, ORG_ADMIN | Deactivate |
-| PATCH | /api/orgs/members/{id}/activate | ORG_OWNER, ORG_ADMIN | Reactivate |
-| DELETE | /api/orgs/members/{id} | ORG_OWNER, ORG_ADMIN | Remove |
-
-**Permission checks** are enforced in the route layer.
-**Service layer** is pure database operations.
-
-The owner cannot be deactivated, removed, or have their role changed.
-Admins can manage employees and viewers but not other admins or the owner.
-
-**Invite flow:** When inviting an email that hasn't signed up yet, a
-placeholder user is created. When they sign up via Cognito, the
-placeholder is automatically claimed and their membership activated.
-Duplicate invites (active member or pending placeholder) return 400.
-
-### Invite emails
-When inviting a new email (not yet in the system), Cognito
-automatically creates their account and sends an invite email
-with a temporary password. The invite uses `admin_create_user`
-via boto3.
-
-Required in `.env`:
-- `AWS_ACCESS_KEY_ID` — IAM user with CognitoPowerUser access
-- `AWS_SECRET_ACCESS_KEY` — corresponding secret key
-
-If the email already has a Cognito account, the invite only
-creates the org membership (no duplicate Cognito account).
-
-## Suppliers
-
-| Method | Endpoint | Role Required | Description |
-|---|---|---|---|
-| GET | /api/suppliers | Any org member | List suppliers |
-| GET | /api/suppliers/{id} | Any org member | Get supplier |
-| POST | /api/suppliers | Any org member | Create supplier |
-| PUT | /api/suppliers/{id} | Any org member | Update supplier |
-| DELETE | /api/suppliers/{id} | ORG_OWNER, ORG_ADMIN | Delete supplier |
-
-All supplier data is scoped to the current user's org. You can
-only see and manage suppliers belonging to your organization.
-
-## Products
-
-| Method | Endpoint | Role Required | Description |
-|---|---|---|---|
-| GET | /api/products | Any org member | List products |
-| GET | /api/products/{id} | Any org member | Get product (with suppliers) |
-| POST | /api/products | Any org member | Create product |
-| PUT | /api/products/{id} | Any org member | Update product |
-| DELETE | /api/products/{id} | ORG_OWNER, ORG_ADMIN | Delete product |
-
-All product data is scoped to the current user's org.
-
-### Product-Supplier Links
-
-Each product can have multiple suppliers. The `is_active` flag on a
-link lets you deactivate a supplier for one product without affecting
-their status on other products (e.g. stop using Supplier X for apples
-but keep them for oranges).
-
-| Method | Endpoint | Role Required | Description |
-|---|---|---|---|
-| GET | /api/products/{id}/suppliers | Any org member | List linked suppliers |
-| POST | /api/products/{id}/suppliers | Any org member | Link a supplier |
-| PATCH | /api/products/{id}/suppliers/{supplier_id} | Any org member | Toggle is_active |
-| DELETE | /api/products/{id}/suppliers/{supplier_id} | Any org member | Remove link |
-
-- Duplicate links return **409 Conflict**.
-- The supplier must belong to the same org as the product.
-
-## System Admin — Organization Management
-
-| Method | Endpoint | Role Required | Description |
-|---|---|---|---|
-| POST | /api/admin/orgs | SYSTEM_ADMIN | Create org + assign owner |
-| GET | /api/admin/orgs | SYSTEM_ADMIN | List all organizations |
-
-**Onboarding a new client:**
-1. System admin calls POST /api/admin/orgs with org name + owner email
-2. If the email is new → Cognito invite sent, placeholder created
-3. If the email exists → they become the active owner immediately
-4. Owner logs in → can invite their own team members
-
-**Becoming a system admin:**
-Currently manual — update the `system_role` column in the database:
-docker compose exec db psql -U postgres -d easyinventory \
--c "UPDATE users SET system_role = 'SYSTEM_ADMIN' WHERE email = 'admin@company.com';"
-This will be replaced by a proper endpoint in a future sprint.
+## Quick Start
 
 ```bash
-# Run migrations
-docker compose exec api alembic upgrade head
-
-# Generate a new migration
-docker compose exec api alembic revision --autogenerate -m "description"
-
-# Rollback last migration
-docker compose exec api alembic downgrade -1
-
-# View migration history
-docker compose exec api alembic history
-
-# Connect to the database directly
-docker compose exec db psql -U postgres -d easyinventory
-```
-
-Running Alembic locally will fail because `db` (the Postgres hostname)
-only resolves inside the Docker network.
-
-## Testing
-
-### Existing suite (`tests/`)
-
-Uses mocked database sessions. No real Postgres needed:
-
-```bash
-make test           # all tests
-make test-unit      # unit only
-make test-functional # functional only
-```
-
-### Real-database suite (`testsv2/`)
-
-Runs against a real Postgres instance with transaction-per-test rollback:
-
-```bash
-# 1. Start a disposable test database (port 5433)
-make test-db
-
-# 2. Run migrations + tests
-make test-v2
-
-# 3. Stop the test database when done
-make test-db-stop
-```
-
-The `testsv2/` factories (`create_user`, `create_org`, etc.) insert real
-rows via the test session. Each test's data is automatically rolled back,
-so tests are fully isolated and can run in any order.
-
-## Local Dev Without Docker
-
-Use this if you want to run the API directly on your machine.
-You still need PostgreSQL running (via Docker or installed locally).
-
-```bash
-# 1. Clone the repository (skip if already done)
-git clone https://github.com/your-org/easyinventory-api.git
+git clone <repo-url>
 cd easyinventory-api
-
-# 2. Create a Python virtual environment
-python -m venv venv
-
-# 3. Activate the virtual environment
-source venv/bin/activate        # macOS / Linux
-# venv\Scripts\activate          # Windows
-
-# 4. Install all dependencies (app + dev tools)
-pip install -r dev-requirements.txt
-
-# 5. Create your environment file
-cp .env.example .env
-
-# 6. Update DATABASE_URL in .env to point to localhost (not "db")
-#    DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/easyinventory
-
-# 7. Start Postgres via Docker (if not already running)
-docker run -d --name easyinventory-db \
-  -e POSTGRES_USER=postgres \
-  -e POSTGRES_PASSWORD=postgres \
-  -e POSTGRES_DB=easyinventory \
-  -p 5432:5432 \
-  postgres:16
-
-# 8. Run database migrations
-python -m alembic upgrade head
-
-# 9. Start the development server
-uvicorn app.main:app --reload
-
-# 10. Verify everything is working
-curl http://localhost:8000/health
-# → {"status": "healthy", "service": "easyinventory-api"}
+cp .env.example .env        # Add your Cognito credentials
+docker compose up --build    # API at http://localhost:8000
 ```
 
-> **Tip:** Every time you open a new terminal, re-activate the virtual
-> environment with `source venv/bin/activate` before running commands.
+Interactive API docs: [http://localhost:8000/docs](http://localhost:8000/docs)
+
+## Documentation
+
+| Guide | Description |
+|---|---|
+| [Getting Started](docs/getting-started.md) | Prerequisites, installation (Docker & local), environment variables |
+| [Architecture](docs/architecture.md) | Project structure, request lifecycle, multi-tenancy, RBAC, database models |
+| [API Reference](docs/api-reference.md) | All endpoints, request/response schemas, invite flow details |
+| [Developer Guide](docs/developer-guide.md) | Contributing, testing (both suites), adding features, Makefile reference |
+| [Deployment Guide](docs/deployment-guide.md) | Docker images, ECR, Caddy, production setup, deploy script |
+| [Troubleshooting](docs/troubleshooting.md) | Common issues and fixes for dev, testing, and production |
+| [Cognito Setup](docs/cognito-setup.md) | AWS Cognito User Pool configuration |
 
 ## Project Structure
 
 ```
 app/
-├── main.py                  # App factory, CORS, lifespan DB check
-├── core/                    # Shared infrastructure
-│   ├── config.py            #   Environment-based settings (pydantic)
-│   ├── database.py          #   SQLAlchemy engine, session, get_db
-│   ├── exceptions.py        #   Domain exception hierarchy (AppError)
-│   ├── middleware.py        #   JSON logging, request logging middleware
-│   └── roles.py             #   SystemRole / OrgRole constants
-├── auth/                    # Authentication domain
-│   ├── cognito_token.py     #   JWKS fetch, JWT verification (hot path)
-│   ├── cognito_admin.py     #   Cognito admin ops: invite, delete (cold path)
-│   ├── deps.py              #   get_current_user, require_role dependencies
-│   ├── routes.py            #   GET /api/me
-│   └── schemas.py           #   UserResponse
-├── orgs/                    # Organization management domain
-│   ├── deps.py              #   get_current_org_membership, require_org_role
-│   ├── permissions.py       #   Permission assertion helpers
-│   ├── routes.py            #   Organization member endpoints
-│   ├── schemas.py           #   Org Pydantic schemas
-│   └── service.py           #   Member CRUD (pure DB operations)
-├── admin/                   # System admin domain
-│   ├── routes_orgs.py       #   Admin org CRUD + status + introspection
-│   ├── routes_users.py      #   Admin user listing + deletion
-│   ├── schemas.py           #   Admin-specific schemas
-│   └── service.py           #   System-admin operations
-├── users/                   # User lifecycle domain
-│   └── service.py           #   get_or_create_user, delete_user, etc.
-├── invites/                 # Invite orchestration domain
-│   └── service.py           #   invite_user_to_org (Cognito + DB)
-├── products/                # Products domain
-│   ├── routes.py            #   Product CRUD + supplier link endpoints
-│   ├── schemas.py           #   Product Pydantic schemas
-│   └── service.py           #   Product data access
-├── suppliers/               # Suppliers domain
-│   ├── routes.py            #   Supplier CRUD endpoints
-│   ├── schemas.py           #   Supplier Pydantic schemas
-│   └── service.py           #   Supplier data access
-├── bootstrap/               # Startup seeding
-│   ├── seeder.py            #   run_bootstrap (admin + sample data)
-│   └── seed_data.py         #   SEED_SUPPLIERS, SEED_PRODUCTS dicts
-├── health/                  # Health check
-│   └── routes.py            #   GET /health
-└── models/                  # SQLAlchemy ORM models
-    ├── base.py              #   Abstract base (UUID pk + created_at)
-    ├── user.py              #   User (cognito_sub, system_role)
-    ├── organization.py      #   Organization
-    ├── org_membership.py    #   OrgMembership (role + FKs)
-    ├── supplier.py          #   Supplier (org-scoped)
-    ├── product.py           #   Product (org-scoped)
-    └── product_supplier.py  #   Product ↔ Supplier join (is_active)
-alembic/
-├── env.py                   # Async migration runner
-└── versions/                # Migration files (auto-generated)
-tests/                       # Existing test suite (mocked DB)
-├── conftest.py              #   Shared fixtures (app, async client)
-├── unit/                    #   Pure logic tests (no HTTP, no DB)
-└── functional/              #   HTTP endpoint tests via test client
-testsv2/                     # Real-database test suite (new)
-├── conftest.py              #   DB engine, transaction-per-test rollback
-├── factories.py             #   Factory functions that INSERT real rows
-├── integration/             #   Service-layer tests against real Postgres
-└── functional/              #   HTTP endpoint tests against real Postgres
-    └── conftest.py          #   Auth bypass fixture
+├── main.py              # App factory
+├── core/                # Config, database, exceptions, middleware, roles
+├── auth/                # Cognito JWT verification, auth dependencies
+├── orgs/                # Organization membership management
+├── admin/               # System admin endpoints
+├── products/            # Product CRUD
+├── suppliers/           # Supplier CRUD
+├── invites/             # Invite orchestration (Cognito + DB)
+├── users/               # User lifecycle
+├── bootstrap/           # Startup seeding
+├── health/              # Health check
+└── models/              # SQLAlchemy ORM models
 ```
 
-## Environment Variables
+## Common Commands
 
-See `.env.example` for all required variables. Key ones:
+| Command | Description |
+|---|---|
+| `make run` | Start dev server (Docker Compose) |
+| `make test` | Run tests (mocked DB) |
+| `make test-v2` | Run tests (real Postgres) |
+| `make format` | Auto-format with Black |
+| `make typecheck` | Run mypy type checking |
+| `make migrate` | Apply database migrations |
+| `make db-shell` | Open psql shell |
 
-| Variable | Used In | Description |
-|---|---|---|
-| `DATABASE_URL` | PR-02 | Postgres connection string |
-| `COGNITO_REGION` | PR-03 | AWS region for Cognito |
-| `COGNITO_USER_POOL_ID` | PR-03 | Cognito User Pool ID |
-| `COGNITO_APP_CLIENT_ID` | PR-03 | Cognito App Client ID |
-| `BOOTSTRAP_ADMIN_EMAIL` | PR-06 | Email to auto-promote to SYSTEM_ADMIN |
-
-## Branch Workflow
-
-```
-feature branch (S1-XX/description)
-  → PR into dev (during sprint)
-    → PR into main (end of sprint, after testing)
-```
-
-All PRs require 1 approval + passing CI (black, mypy, pytest).
-
-
----
- 
-## Commit Message Convention
- 
-Use this format for every commit:
- 
-```
-<type>: <short description>
- 
-Types:
-  init  — project setup, scaffolding
-  add   — new feature or file
-  fix   — bug fix
-  test  — adding or updating tests
-  docs  — documentation only
-  refactor — code change that doesn't add/fix
-  chore — config, dependencies, CI
- 
-Examples:
-  init: FastAPI project with folder structure
-  add: User model with cognito_sub and system_role
-  add: JWT validation middleware with 401/403 responses
-  fix: duplicate user creation on concurrent first logins
-  test: auth middleware returns 401 for expired tokens
-  docs: Cognito User Pool setup instructions
-```
- 
----
- 
-## PR Review Checklist
- 
-Before approving any PR:
- 
-- [ ] Code runs locally (docker compose up, tests pass)
-- [ ] No hardcoded secrets or credentials
-- [ ] New env vars are documented in .env.example
-- [ ] Database changes have an Alembic migration
-- [ ] API changes include request/response schemas
-- [ ] At least one test for new functionality
-- [ ] PR description explains what and why
+See the [Developer Guide](docs/developer-guide.md) for the full Makefile reference.

--- a/app/admin/routes_orgs.py
+++ b/app/admin/routes_orgs.py
@@ -6,7 +6,6 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, func
 
 from app.admin import service as admin_service
 from app.admin.schemas import (
@@ -103,40 +102,7 @@ async def list_orgs(
     db: AsyncSession = Depends(get_db),
 ) -> list[OrgListItem]:
     """List all organizations. System admin only."""
-    # Compute owner_email and member_count via SQL aggregates to avoid
-    # materializing full membership and user collections for every org.
-    owner_subq = (
-        select(
-            OrgMembership.org_id,
-            User.email.label("owner_email"),
-        )
-        .join(User, User.id == OrgMembership.user_id)
-        .where(OrgMembership.org_role == OrgRole.OWNER)
-        .subquery()
-    )
-
-    stmt = (
-        select(
-            Organization.id,
-            Organization.name,
-            Organization.created_at,
-            func.count(OrgMembership.id).label("member_count"),
-            owner_subq.c.owner_email,
-        )
-        .select_from(Organization)
-        .join(OrgMembership, OrgMembership.org_id == Organization.id, isouter=True)
-        .join(owner_subq, owner_subq.c.org_id == Organization.id, isouter=True)
-        .group_by(
-            Organization.id,
-            Organization.name,
-            Organization.created_at,
-            owner_subq.c.owner_email,
-        )
-    )
-
-    result = await db.execute(stmt)
-    rows = result.all()
-
+    rows = await admin_service.list_orgs_with_details(db)
     return [
         OrgListItem(
             id=row.id,
@@ -160,38 +126,9 @@ async def rename_org(
     org = await _get_org_or_404(db, org_id)
     org = await admin_service.rename_org(db, org, body.name)
 
-    # After renaming, compute owner_email and member_count via aggregates
-    # instead of traversing org.memberships to avoid loading related collections.
-    owner_subq = (
-        select(
-            OrgMembership.org_id,
-            User.email.label("owner_email"),
-        )
-        .join(User, User.id == OrgMembership.user_id)
-        .where(
-            OrgMembership.org_role == OrgRole.OWNER,
-            OrgMembership.org_id == org.id,
-        )
-        .subquery()
+    owner_email, member_count = await admin_service.get_org_owner_and_member_count(
+        db, org.id
     )
-
-    stmt = (
-        select(
-            func.count(OrgMembership.id).label("member_count"),
-            owner_subq.c.owner_email,
-        )
-        .select_from(Organization)
-        .join(OrgMembership, OrgMembership.org_id == Organization.id, isouter=True)
-        .join(owner_subq, owner_subq.c.org_id == Organization.id, isouter=True)
-        .where(Organization.id == org.id)
-        .group_by(owner_subq.c.owner_email)
-    )
-
-    result = await db.execute(stmt)
-    row = result.one_or_none()
-
-    owner_email = row.owner_email if row is not None else None
-    member_count = row.member_count if row is not None else 0
 
     return OrgListItem(
         id=org.id,

--- a/app/admin/routes_orgs.py
+++ b/app/admin/routes_orgs.py
@@ -6,6 +6,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, func
 
 from app.admin import service as admin_service
 from app.admin.schemas import (
@@ -102,19 +103,49 @@ async def list_orgs(
     db: AsyncSession = Depends(get_db),
 ) -> list[OrgListItem]:
     """List all organizations. System admin only."""
-    orgs = await admin_service.list_all_orgs(db)
+    # Compute owner_email and member_count via SQL aggregates to avoid
+    # materializing full membership and user collections for every org.
+    owner_subq = (
+        select(
+            OrgMembership.org_id,
+            User.email.label("owner_email"),
+        )
+        .join(User, User.id == OrgMembership.user_id)
+        .where(OrgMembership.org_role == OrgRole.OWNER)
+        .subquery()
+    )
+
+    stmt = (
+        select(
+            Organization.id,
+            Organization.name,
+            Organization.created_at,
+            func.count(OrgMembership.id).label("member_count"),
+            owner_subq.c.owner_email,
+        )
+        .select_from(Organization)
+        .join(OrgMembership, OrgMembership.org_id == Organization.id, isouter=True)
+        .join(owner_subq, owner_subq.c.org_id == Organization.id, isouter=True)
+        .group_by(
+            Organization.id,
+            Organization.name,
+            Organization.created_at,
+            owner_subq.c.owner_email,
+        )
+    )
+
+    result = await db.execute(stmt)
+    rows = result.all()
+
     return [
         OrgListItem(
-            id=org.id,
-            name=org.name,
-            created_at=org.created_at,
-            owner_email=next(
-                (m.user.email for m in org.memberships if m.org_role == OrgRole.OWNER),
-                None,
-            ),
-            member_count=len(org.memberships),
+            id=row.id,
+            name=row.name,
+            created_at=row.created_at,
+            owner_email=row.owner_email,
+            member_count=row.member_count,
         )
-        for org in orgs
+        for row in rows
     ]
 
 
@@ -129,15 +160,45 @@ async def rename_org(
     org = await _get_org_or_404(db, org_id)
     org = await admin_service.rename_org(db, org, body.name)
 
+    # After renaming, compute owner_email and member_count via aggregates
+    # instead of traversing org.memberships to avoid loading related collections.
+    owner_subq = (
+        select(
+            OrgMembership.org_id,
+            User.email.label("owner_email"),
+        )
+        .join(User, User.id == OrgMembership.user_id)
+        .where(
+            OrgMembership.org_role == OrgRole.OWNER,
+            OrgMembership.org_id == org.id,
+        )
+        .subquery()
+    )
+
+    stmt = (
+        select(
+            func.count(OrgMembership.id).label("member_count"),
+            owner_subq.c.owner_email,
+        )
+        .select_from(Organization)
+        .join(OrgMembership, OrgMembership.org_id == Organization.id, isouter=True)
+        .join(owner_subq, owner_subq.c.org_id == Organization.id, isouter=True)
+        .where(Organization.id == org.id)
+        .group_by(owner_subq.c.owner_email)
+    )
+
+    result = await db.execute(stmt)
+    row = result.one_or_none()
+
+    owner_email = row.owner_email if row is not None else None
+    member_count = row.member_count if row is not None else 0
+
     return OrgListItem(
         id=org.id,
         name=org.name,
         created_at=org.created_at,
-        owner_email=next(
-            (m.user.email for m in org.memberships if m.org_role == OrgRole.OWNER),
-            None,
-        ),
-        member_count=len(org.memberships),
+        owner_email=owner_email,
+        member_count=member_count,
     )
 
 

--- a/app/admin/routes_orgs.py
+++ b/app/admin/routes_orgs.py
@@ -17,12 +17,12 @@ from app.admin.schemas import (
 from app.auth.deps import require_role
 from app.core.database import get_db
 from app.core.roles import OrgRole, SystemRole
+from app.models.org_membership import OrgMembership
 from app.models.organization import Organization
 from app.models.user import User
 from app.orgs import service as org_service
 from app.orgs.schemas import OrgMemberDetail
 from app.invites.service import invite_user_to_org
-from app.users import service as user_service
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
@@ -68,7 +68,7 @@ async def create_org(
     body: CreateOrgRequest,
     current_user: User = Depends(require_role(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
-) -> dict:
+) -> OrgListItem:
     """
     Create a new organization and assign an owner.
 
@@ -87,22 +87,35 @@ async def create_org(
         is_new_org=True,
     )
 
-    return {
-        "id": org.id,
-        "name": org.name,
-        "created_at": org.created_at,
-        "owner_email": body.owner_email,
-        "member_count": 1,
-    }
+    return OrgListItem(
+        id=org.id,
+        name=org.name,
+        created_at=org.created_at,
+        owner_email=body.owner_email,
+        member_count=1,
+    )
 
 
 @router.get("/orgs", response_model=list[OrgListItem])
 async def list_orgs(
     current_user: User = Depends(require_role(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
-) -> list[dict]:
+) -> list[OrgListItem]:
     """List all organizations. System admin only."""
-    return await admin_service.list_all_orgs(db)
+    orgs = await admin_service.list_all_orgs(db)
+    return [
+        OrgListItem(
+            id=org.id,
+            name=org.name,
+            created_at=org.created_at,
+            owner_email=next(
+                (m.user.email for m in org.memberships if m.org_role == OrgRole.OWNER),
+                None,
+            ),
+            member_count=len(org.memberships),
+        )
+        for org in orgs
+    ]
 
 
 @router.patch("/orgs/{org_id}", response_model=OrgListItem)
@@ -111,21 +124,21 @@ async def rename_org(
     body: UpdateOrgRequest,
     current_user: User = Depends(require_role(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
-) -> dict:
+) -> OrgListItem:
     """Rename an organization. System admin only."""
     org = await _get_org_or_404(db, org_id)
     org = await admin_service.rename_org(db, org, body.name)
 
-    # Re-fetch owner info for the response
-    all_orgs = await admin_service.list_all_orgs(db)
-    matched = next((o for o in all_orgs if o["id"] == org.id), None)
-    return matched or {
-        "id": org.id,
-        "name": org.name,
-        "created_at": org.created_at,
-        "owner_email": None,
-        "member_count": 0,
-    }
+    return OrgListItem(
+        id=org.id,
+        name=org.name,
+        created_at=org.created_at,
+        owner_email=next(
+            (m.user.email for m in org.memberships if m.org_role == OrgRole.OWNER),
+            None,
+        ),
+        member_count=len(org.memberships),
+    )
 
 
 @router.delete("/orgs/{org_id}", status_code=204)
@@ -145,25 +158,15 @@ async def transfer_ownership(
     body: TransferOwnershipRequest,
     current_user: User = Depends(require_role(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
-) -> dict:
+) -> OrgMembership:
     """Transfer org ownership to another member. System admin only."""
     await _get_org_or_404(db, org_id)
 
-    new_owner_membership = await admin_service.transfer_ownership(
+    return await admin_service.transfer_ownership(
         db,
         org_id,
         body.new_owner_email,
     )
-
-    user = await user_service.get_user_by_id(db, new_owner_membership.user_id)
-    return {
-        "id": new_owner_membership.id,
-        "user_id": new_owner_membership.user_id,
-        "email": user.email if user else "",
-        "org_role": new_owner_membership.org_role,
-        "is_active": new_owner_membership.is_active,
-        "joined_at": new_owner_membership.joined_at,
-    }
 
 
 # ── Org member introspection ──
@@ -174,7 +177,7 @@ async def list_org_members(
     org_id: uuid.UUID,
     current_user: User = Depends(require_role(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
-) -> list[dict]:
+) -> list[OrgMembership]:
     """List all members of a specific org. System admin only."""
     await _get_org_or_404(db, org_id)
     return await org_service.list_org_members(db=db, org_id=org_id)

--- a/app/admin/routes_orgs.py
+++ b/app/admin/routes_orgs.py
@@ -14,7 +14,7 @@ from app.admin.schemas import (
     TransferOwnershipRequest,
     UpdateOrgRequest,
 )
-from app.auth.deps import require_role
+from app.auth.deps import RequireRole
 from app.core.database import get_db
 from app.core.roles import OrgRole, SystemRole
 from app.models.org_membership import OrgMembership
@@ -45,7 +45,7 @@ async def _get_org_or_404(
 
 @router.get("/status")
 async def admin_status(
-    user: User = Depends(require_role(SystemRole.ADMIN)),
+    user: User = Depends(RequireRole(SystemRole.ADMIN)),
 ) -> dict:
     """
     Admin-only endpoint for testing role enforcement.
@@ -66,7 +66,7 @@ async def admin_status(
 @router.post("/orgs", response_model=OrgListItem, status_code=201)
 async def create_org(
     body: CreateOrgRequest,
-    current_user: User = Depends(require_role(SystemRole.ADMIN)),
+    current_user: User = Depends(RequireRole(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> OrgListItem:
     """
@@ -98,7 +98,7 @@ async def create_org(
 
 @router.get("/orgs", response_model=list[OrgListItem])
 async def list_orgs(
-    current_user: User = Depends(require_role(SystemRole.ADMIN)),
+    current_user: User = Depends(RequireRole(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> list[OrgListItem]:
     """List all organizations. System admin only."""
@@ -122,7 +122,7 @@ async def list_orgs(
 async def rename_org(
     org_id: uuid.UUID,
     body: UpdateOrgRequest,
-    current_user: User = Depends(require_role(SystemRole.ADMIN)),
+    current_user: User = Depends(RequireRole(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> OrgListItem:
     """Rename an organization. System admin only."""
@@ -144,7 +144,7 @@ async def rename_org(
 @router.delete("/orgs/{org_id}", status_code=204)
 async def delete_org(
     org_id: uuid.UUID,
-    current_user: User = Depends(require_role(SystemRole.ADMIN)),
+    current_user: User = Depends(RequireRole(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> None:
     """Delete an organization and all its memberships. System admin only."""
@@ -156,7 +156,7 @@ async def delete_org(
 async def transfer_ownership(
     org_id: uuid.UUID,
     body: TransferOwnershipRequest,
-    current_user: User = Depends(require_role(SystemRole.ADMIN)),
+    current_user: User = Depends(RequireRole(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> OrgMembership:
     """Transfer org ownership to another member. System admin only."""
@@ -175,7 +175,7 @@ async def transfer_ownership(
 @router.get("/orgs/{org_id}/members", response_model=list[OrgMemberDetail])
 async def list_org_members(
     org_id: uuid.UUID,
-    current_user: User = Depends(require_role(SystemRole.ADMIN)),
+    current_user: User = Depends(RequireRole(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> list[OrgMembership]:
     """List all members of a specific org. System admin only."""

--- a/app/admin/routes_users.py
+++ b/app/admin/routes_users.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.admin import service as admin_service
 from app.admin.schemas import UserListItem
 from app.auth.cognito_admin import delete_cognito_user
-from app.auth.deps import require_role
+from app.auth.deps import RequireRole
 from app.core.database import get_db
 from app.core.roles import SystemRole
 from app.models.user import User
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/api/admin", tags=["admin"])
 
 @router.get("/users", response_model=list[UserListItem])
 async def list_users(
-    current_user: User = Depends(require_role(SystemRole.ADMIN)),
+    current_user: User = Depends(RequireRole(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> list[UserListItem]:
     """List all users across all orgs. System admin only."""
@@ -42,7 +42,7 @@ async def list_users(
 @router.delete("/users/{user_id}", status_code=204)
 async def delete_user(
     user_id: uuid.UUID,
-    current_user: User = Depends(require_role(SystemRole.ADMIN)),
+    current_user: User = Depends(RequireRole(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> None:
     """Delete a user from the local system and Cognito."""

--- a/app/admin/routes_users.py
+++ b/app/admin/routes_users.py
@@ -23,9 +23,20 @@ router = APIRouter(prefix="/api/admin", tags=["admin"])
 async def list_users(
     current_user: User = Depends(require_role(SystemRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
-) -> list[dict]:
+) -> list[UserListItem]:
     """List all users across all orgs. System admin only."""
-    return await admin_service.list_all_users(db)
+    users = await admin_service.list_all_users(db)
+    return [
+        UserListItem(
+            id=user.id,
+            email=user.email,
+            system_role=user.system_role,
+            is_active=user.is_active,
+            created_at=user.created_at,
+            org_count=len([m for m in user.memberships if m.is_active]),
+        )
+        for user in users
+    ]
 
 
 @router.delete("/users/{user_id}", status_code=204)

--- a/app/admin/routes_users.py
+++ b/app/admin/routes_users.py
@@ -5,6 +5,7 @@ Admin user routes — system-admin user management endpoints.
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.admin import service as admin_service
@@ -13,6 +14,7 @@ from app.auth.cognito_admin import delete_cognito_user
 from app.auth.deps import RequireRole
 from app.core.database import get_db
 from app.core.roles import SystemRole
+from app.models.membership import Membership
 from app.models.user import User
 from app.users import service as user_service
 
@@ -26,6 +28,26 @@ async def list_users(
 ) -> list[UserListItem]:
     """List all users across all orgs. System admin only."""
     users = await admin_service.list_all_users(db)
+
+    # Precompute active-organization counts per user in SQL to avoid
+    # materializing full membership collections for every user.
+    user_ids = [user.id for user in users]
+    org_counts: dict[uuid.UUID, int] = {}
+    if user_ids:
+        stmt = (
+            select(Membership.user_id, func.count(Membership.id))
+            .where(
+                Membership.user_id.in_(user_ids),
+                Membership.is_active.is_(True),
+            )
+            .group_by(Membership.user_id)
+        )
+        result = await db.execute(stmt)
+        org_counts = {
+            user_id: count
+            for user_id, count in result.all()
+        }
+
     return [
         UserListItem(
             id=user.id,
@@ -33,7 +55,7 @@ async def list_users(
             system_role=user.system_role,
             is_active=user.is_active,
             created_at=user.created_at,
-            org_count=len([m for m in user.memberships if m.is_active]),
+            org_count=org_counts.get(user.id, 0),
         )
         for user in users
     ]

--- a/app/admin/routes_users.py
+++ b/app/admin/routes_users.py
@@ -5,7 +5,6 @@ Admin user routes — system-admin user management endpoints.
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.admin import service as admin_service
@@ -14,7 +13,6 @@ from app.auth.cognito_admin import delete_cognito_user
 from app.auth.deps import RequireRole
 from app.core.database import get_db
 from app.core.roles import SystemRole
-from app.models.membership import Membership
 from app.models.user import User
 from app.users import service as user_service
 
@@ -27,37 +25,17 @@ async def list_users(
     db: AsyncSession = Depends(get_db),
 ) -> list[UserListItem]:
     """List all users across all orgs. System admin only."""
-    users = await admin_service.list_all_users(db)
-
-    # Precompute active-organization counts per user in SQL to avoid
-    # materializing full membership collections for every user.
-    user_ids = [user.id for user in users]
-    org_counts: dict[uuid.UUID, int] = {}
-    if user_ids:
-        stmt = (
-            select(Membership.user_id, func.count(Membership.id))
-            .where(
-                Membership.user_id.in_(user_ids),
-                Membership.is_active.is_(True),
-            )
-            .group_by(Membership.user_id)
-        )
-        result = await db.execute(stmt)
-        org_counts = {
-            user_id: count
-            for user_id, count in result.all()
-        }
-
+    rows = await admin_service.list_users_with_org_counts(db)
     return [
         UserListItem(
-            id=user.id,
-            email=user.email,
-            system_role=user.system_role,
-            is_active=user.is_active,
-            created_at=user.created_at,
-            org_count=org_counts.get(user.id, 0),
+            id=row.id,
+            email=row.email,
+            system_role=row.system_role,
+            is_active=row.is_active,
+            created_at=row.created_at,
+            org_count=row.org_count,
         )
-        for user in users
+        for row in rows
     ]
 
 

--- a/app/admin/service.py
+++ b/app/admin/service.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import uuid
 from typing import Optional
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import InvalidRole, NotFound
@@ -19,58 +19,14 @@ from app.models.org_membership import OrgMembership
 from app.models.user import User
 
 
-async def list_all_orgs(db: AsyncSession) -> list[dict]:
+async def list_all_orgs(db: AsyncSession) -> list[Organization]:
     """
-    List all organizations with owner email and member count.
+    List all organizations with memberships and users loaded.
     System admin only — returns data across all orgs.
     """
-    # Subquery: count members per org
-    member_count_sq = (
-        select(
-            OrgMembership.org_id,
-            func.count(OrgMembership.id).label("member_count"),
-        )
-        .group_by(OrgMembership.org_id)
-        .subquery()
-    )
-
-    # Subquery: owner email per org
-    owner_sq = (
-        select(
-            OrgMembership.org_id,
-            User.email.label("owner_email"),
-        )
-        .join(User, OrgMembership.user_id == User.id)
-        .where(OrgMembership.org_role == OrgRole.OWNER)
-        .subquery()
-    )
-
-    stmt = (
-        select(
-            Organization.id,
-            Organization.name,
-            Organization.created_at,
-            owner_sq.c.owner_email,
-            func.coalesce(member_count_sq.c.member_count, 0).label("member_count"),
-        )
-        .outerjoin(owner_sq, Organization.id == owner_sq.c.org_id)
-        .outerjoin(member_count_sq, Organization.id == member_count_sq.c.org_id)
-        .order_by(Organization.created_at.desc())
-    )
-
+    stmt = select(Organization).order_by(Organization.created_at.desc())
     result = await db.execute(stmt)
-    rows = result.all()
-
-    return [
-        {
-            "id": row.id,
-            "name": row.name,
-            "created_at": row.created_at,
-            "owner_email": row.owner_email,
-            "member_count": row.member_count,
-        }
-        for row in rows
-    ]
+    return list(result.scalars().all())
 
 
 async def get_org_by_id(
@@ -149,41 +105,8 @@ async def transfer_ownership(
     return new_owner_membership
 
 
-async def list_all_users(db: AsyncSession) -> list[dict]:
-    """List all users with their active org count."""
-    org_count_sq = (
-        select(
-            OrgMembership.user_id,
-            func.count(OrgMembership.id).label("org_count"),
-        )
-        .where(OrgMembership.is_active == True)  # noqa: E712
-        .group_by(OrgMembership.user_id)
-        .subquery()
-    )
-
-    stmt = (
-        select(
-            User.id,
-            User.email,
-            User.system_role,
-            User.is_active,
-            User.created_at,
-            func.coalesce(org_count_sq.c.org_count, 0).label("org_count"),
-        )
-        .outerjoin(org_count_sq, User.id == org_count_sq.c.user_id)
-        .order_by(User.created_at.desc())
-    )
+async def list_all_users(db: AsyncSession) -> list[User]:
+    """List all users with memberships loaded."""
+    stmt = select(User).order_by(User.created_at.desc())
     result = await db.execute(stmt)
-    rows = result.all()
-
-    return [
-        {
-            "id": row.id,
-            "email": row.email,
-            "system_role": row.system_role,
-            "is_active": row.is_active,
-            "created_at": row.created_at,
-            "org_count": row.org_count,
-        }
-        for row in rows
-    ]
+    return list(result.scalars().all())

--- a/app/admin/service.py
+++ b/app/admin/service.py
@@ -7,9 +7,11 @@ These functions are only accessible to SYSTEM_ADMIN users.
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import InvalidRole, NotFound
@@ -17,6 +19,27 @@ from app.core.roles import OrgRole
 from app.models.organization import Organization
 from app.models.org_membership import OrgMembership
 from app.models.user import User
+
+# ── Data containers ──
+
+
+@dataclass
+class UserWithOrgCount:
+    id: uuid.UUID
+    email: str
+    system_role: str
+    is_active: bool
+    created_at: datetime
+    org_count: int
+
+
+@dataclass
+class OrgWithDetails:
+    id: uuid.UUID
+    name: str
+    created_at: datetime
+    owner_email: str | None
+    member_count: int
 
 
 async def list_all_orgs(db: AsyncSession) -> list[Organization]:
@@ -110,3 +133,136 @@ async def list_all_users(db: AsyncSession) -> list[User]:
     stmt = select(User).order_by(User.created_at.desc())
     result = await db.execute(stmt)
     return list(result.scalars().all())
+
+
+# ── Aggregate queries ──
+
+
+async def list_users_with_org_counts(
+    db: AsyncSession,
+) -> list[UserWithOrgCount]:
+    """
+    List all users with their active-organization counts.
+
+    Performs a single aggregate query for org counts instead of
+    materializing full membership collections for every user.
+    """
+    users = await list_all_users(db)
+
+    user_ids = [user.id for user in users]
+    org_counts: dict[uuid.UUID, int] = {}
+    if user_ids:
+        stmt = (
+            select(OrgMembership.user_id, func.count(OrgMembership.id))
+            .where(
+                OrgMembership.user_id.in_(user_ids),
+                OrgMembership.is_active.is_(True),
+            )
+            .group_by(OrgMembership.user_id)
+        )
+        result = await db.execute(stmt)
+        org_counts = {user_id: count for user_id, count in result.all()}
+
+    return [
+        UserWithOrgCount(
+            id=user.id,
+            email=user.email,
+            system_role=user.system_role,
+            is_active=user.is_active,
+            created_at=user.created_at,
+            org_count=org_counts.get(user.id, 0),
+        )
+        for user in users
+    ]
+
+
+async def list_orgs_with_details(db: AsyncSession) -> list[OrgWithDetails]:
+    """
+    List all organizations with owner email and member count.
+
+    Uses SQL aggregates and a subquery to compute owner_email and
+    member_count without materializing full related collections.
+    """
+    owner_subq = (
+        select(
+            OrgMembership.org_id,
+            User.email.label("owner_email"),
+        )
+        .join(User, User.id == OrgMembership.user_id)
+        .where(OrgMembership.org_role == OrgRole.OWNER)
+        .subquery()
+    )
+
+    stmt = (
+        select(
+            Organization.id,
+            Organization.name,
+            Organization.created_at,
+            func.count(OrgMembership.id).label("member_count"),
+            owner_subq.c.owner_email,
+        )
+        .select_from(Organization)
+        .join(OrgMembership, OrgMembership.org_id == Organization.id, isouter=True)
+        .join(owner_subq, owner_subq.c.org_id == Organization.id, isouter=True)
+        .group_by(
+            Organization.id,
+            Organization.name,
+            Organization.created_at,
+            owner_subq.c.owner_email,
+        )
+    )
+
+    result = await db.execute(stmt)
+    return [
+        OrgWithDetails(
+            id=row.id,
+            name=row.name,
+            created_at=row.created_at,
+            owner_email=row.owner_email,
+            member_count=row.member_count,
+        )
+        for row in result.all()
+    ]
+
+
+async def get_org_owner_and_member_count(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+) -> tuple[str | None, int]:
+    """
+    Return ``(owner_email, member_count)`` for a single organization.
+
+    Used after mutations (e.g. rename) to build the response without
+    loading full related collections.
+    """
+    owner_subq = (
+        select(
+            OrgMembership.org_id,
+            User.email.label("owner_email"),
+        )
+        .join(User, User.id == OrgMembership.user_id)
+        .where(
+            OrgMembership.org_role == OrgRole.OWNER,
+            OrgMembership.org_id == org_id,
+        )
+        .subquery()
+    )
+
+    stmt = (
+        select(
+            func.count(OrgMembership.id).label("member_count"),
+            owner_subq.c.owner_email,
+        )
+        .select_from(Organization)
+        .join(OrgMembership, OrgMembership.org_id == Organization.id, isouter=True)
+        .join(owner_subq, owner_subq.c.org_id == Organization.id, isouter=True)
+        .where(Organization.id == org_id)
+        .group_by(owner_subq.c.owner_email)
+    )
+
+    result = await db.execute(stmt)
+    row = result.one_or_none()
+
+    owner_email = row.owner_email if row is not None else None
+    member_count = row.member_count if row is not None else 0
+    return owner_email, member_count

--- a/app/auth/deps.py
+++ b/app/auth/deps.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 from fastapi import Depends, HTTPException, status
@@ -61,16 +60,17 @@ async def get_current_user(
     return user
 
 
-def require_role(*allowed_roles: str) -> Callable[..., Any]:
+class RequireRole:
     """
-    Dependency factory that checks the user's system_role.
+    Callable dependency that checks the user's system_role.
 
-    Usage:
+    Usage::
+
         from app.core.roles import SystemRole
 
         @router.get("/admin-only")
         async def admin_only(
-            user: User = Depends(require_role(SystemRole.ADMIN)),
+            user: User = Depends(RequireRole(SystemRole.ADMIN)),
         ):
             ...
 
@@ -78,14 +78,16 @@ def require_role(*allowed_roles: str) -> Callable[..., Any]:
     Raises 403 if they don't.
     """
 
-    async def _check_role(
+    def __init__(self, *allowed_roles: str):
+        self.allowed_roles = allowed_roles
+
+    async def __call__(
+        self,
         current_user: User = Depends(get_current_user),
     ) -> User:
-        if current_user.system_role not in allowed_roles:
+        if current_user.system_role not in self.allowed_roles:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Insufficient permissions",
             )
         return current_user
-
-    return _check_role

--- a/app/core/roles.py
+++ b/app/core/roles.py
@@ -7,8 +7,8 @@ Usage:
     if user.system_role == SystemRole.ADMIN:
         ...
 
-    require_role(SystemRole.ADMIN)
-    require_org_role(OrgRole.OWNER, OrgRole.ADMIN)
+    RequireRole(SystemRole.ADMIN)
+    RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)
 
 These are plain string constants (not enums) so they stay compatible
 with SQLAlchemy column defaults, Pydantic schemas, and existing DB

--- a/app/models/org_membership.py
+++ b/app/models/org_membership.py
@@ -46,4 +46,4 @@ class OrgMembership(BaseModel):
     @property
     def email(self) -> str:
         """Expose user email for Pydantic serialization."""
-        return self.user.email if self.user else ""
+        return self.user.email

--- a/app/models/org_membership.py
+++ b/app/models/org_membership.py
@@ -42,3 +42,8 @@ class OrgMembership(BaseModel):
     organization: Mapped[Organization] = relationship(
         back_populates="memberships", lazy="selectin"
     )
+
+    @property
+    def email(self) -> str:
+        """Expose user email for Pydantic serialization."""
+        return self.user.email if self.user else ""

--- a/app/orgs/deps.py
+++ b/app/orgs/deps.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Callable
-from typing import Any
 
 from fastapi import Depends, Header, HTTPException, status
 from sqlalchemy import select
@@ -74,28 +72,31 @@ async def get_current_org_membership(
     return membership
 
 
-def require_org_role(*allowed_roles: str) -> Callable[..., Any]:
+class RequireOrgRole:
     """
-    Dependency factory: checks the user's org_role.
+    Callable dependency that checks the user's org_role.
 
-    Usage:
+    Usage::
+
         from app.core.roles import OrgRole
 
         @router.post("/invite")
         async def invite(
-            membership = Depends(require_org_role(OrgRole.OWNER, OrgRole.ADMIN)),
+            membership = Depends(RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)),
         ):
             ...
     """
 
-    async def _check_org_role(
+    def __init__(self, *allowed_roles: str):
+        self.allowed_roles = allowed_roles
+
+    async def __call__(
+        self,
         membership: OrgMembership = Depends(get_current_org_membership),
     ) -> OrgMembership:
-        if membership.org_role not in allowed_roles:
+        if membership.org_role not in self.allowed_roles:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Insufficient org permissions",
             )
         return membership
-
-    return _check_org_role

--- a/app/orgs/routes.py
+++ b/app/orgs/routes.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from app.auth.deps import get_current_user
 from app.orgs.deps import (
     get_current_org_membership,
-    require_org_role,
+    RequireOrgRole,
 )
 from app.orgs.permissions import (
     assert_admin_hierarchy,
@@ -83,7 +83,7 @@ async def list_members(
 async def invite_member(
     body: InviteMemberRequest,
     membership: OrgMembership = Depends(
-        require_org_role(OrgRole.OWNER, OrgRole.ADMIN),
+        RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN),
     ),
     db: AsyncSession = Depends(get_db),
 ) -> OrgMembership:
@@ -104,7 +104,7 @@ async def update_role(
     member_id: uuid.UUID,
     body: UpdateRoleRequest,
     membership: OrgMembership = Depends(
-        require_org_role(OrgRole.OWNER, OrgRole.ADMIN),
+        RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN),
     ),
     db: AsyncSession = Depends(get_db),
 ) -> OrgMembership:
@@ -123,7 +123,7 @@ async def update_role(
 async def deactivate_member(
     member_id: uuid.UUID,
     membership: OrgMembership = Depends(
-        require_org_role(OrgRole.OWNER, OrgRole.ADMIN),
+        RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN),
     ),
     db: AsyncSession = Depends(get_db),
 ) -> OrgMembership:
@@ -140,7 +140,7 @@ async def deactivate_member(
 async def activate_member(
     member_id: uuid.UUID,
     membership: OrgMembership = Depends(
-        require_org_role(OrgRole.OWNER, OrgRole.ADMIN),
+        RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN),
     ),
     db: AsyncSession = Depends(get_db),
 ) -> OrgMembership:
@@ -154,7 +154,7 @@ async def activate_member(
 async def remove_member(
     member_id: uuid.UUID,
     membership: OrgMembership = Depends(
-        require_org_role(OrgRole.OWNER, OrgRole.ADMIN),
+        RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN),
     ),
     db: AsyncSession = Depends(get_db),
 ) -> None:

--- a/app/orgs/routes.py
+++ b/app/orgs/routes.py
@@ -29,7 +29,6 @@ from app.orgs.schemas import (
     UpdateRoleRequest,
 )
 from app.orgs import service as org_service
-from app.users import service as user_service
 from app.invites.service import invite_user_to_org
 
 router = APIRouter(prefix="/api/orgs", tags=["organizations"])
@@ -50,24 +49,6 @@ async def _get_target_or_404(
             detail="Membership not found",
         )
     return target
-
-
-async def _member_detail(
-    db: AsyncSession,
-    membership: OrgMembership,
-    email: str | None = None,
-) -> dict:
-    if not email:
-        user = await user_service.get_user_by_id(db, membership.user_id)
-        email = user.email if user else ""
-    return {
-        "id": membership.id,
-        "user_id": membership.user_id,
-        "email": email,
-        "org_role": membership.org_role,
-        "is_active": membership.is_active,
-        "joined_at": membership.joined_at,
-    }
 
 
 # ── Endpoints ──
@@ -93,7 +74,7 @@ async def get_my_orgs(
 async def list_members(
     membership: OrgMembership = Depends(get_current_org_membership),
     db: AsyncSession = Depends(get_db),
-) -> list[dict]:
+) -> list[OrgMembership]:
     """List all members of the current user's org."""
     return await org_service.list_org_members(db=db, org_id=membership.org_id)
 
@@ -105,19 +86,17 @@ async def invite_member(
         require_org_role(OrgRole.OWNER, OrgRole.ADMIN),
     ),
     db: AsyncSession = Depends(get_db),
-) -> dict:
+) -> OrgMembership:
     """Invite a user to the org by email."""
     assert_valid_invite_role(body.org_role)
     assert_can_assign_role(membership.org_role, body.org_role)
 
-    new_membership = await invite_user_to_org(
+    return await invite_user_to_org(
         db=db,
         org_id=membership.org_id,
         email=body.email,
         org_role=body.org_role,
     )
-
-    return await _member_detail(db, new_membership, email=body.email)
 
 
 @router.patch("/members/{member_id}/role", response_model=OrgMemberDetail)
@@ -128,7 +107,7 @@ async def update_role(
         require_org_role(OrgRole.OWNER, OrgRole.ADMIN),
     ),
     db: AsyncSession = Depends(get_db),
-) -> dict:
+) -> OrgMembership:
     """Change a member's org role."""
     target = await _get_target_or_404(db, member_id, membership.org_id)
 
@@ -137,8 +116,7 @@ async def update_role(
     assert_admin_hierarchy(membership.org_role, target.org_role, "change role of")
     assert_can_assign_role(membership.org_role, body.org_role)
 
-    updated = await org_service.update_role(db, target, body.org_role)
-    return await _member_detail(db, updated)
+    return await org_service.update_role(db, target, body.org_role)
 
 
 @router.patch("/members/{member_id}/deactivate", response_model=OrgMemberDetail)
@@ -148,15 +126,14 @@ async def deactivate_member(
         require_org_role(OrgRole.OWNER, OrgRole.ADMIN),
     ),
     db: AsyncSession = Depends(get_db),
-) -> dict:
+) -> OrgMembership:
     """Deactivate a member."""
     target = await _get_target_or_404(db, member_id, membership.org_id)
 
     assert_not_owner(target, "deactivate")
     assert_admin_hierarchy(membership.org_role, target.org_role, "deactivate")
 
-    updated = await org_service.set_active_status(db, target, is_active=False)
-    return await _member_detail(db, updated)
+    return await org_service.set_active_status(db, target, is_active=False)
 
 
 @router.patch("/members/{member_id}/activate", response_model=OrgMemberDetail)
@@ -166,12 +143,11 @@ async def activate_member(
         require_org_role(OrgRole.OWNER, OrgRole.ADMIN),
     ),
     db: AsyncSession = Depends(get_db),
-) -> dict:
+) -> OrgMembership:
     """Reactivate a deactivated member."""
     target = await _get_target_or_404(db, member_id, membership.org_id)
 
-    updated = await org_service.set_active_status(db, target, is_active=True)
-    return await _member_detail(db, updated)
+    return await org_service.set_active_status(db, target, is_active=True)
 
 
 @router.delete("/members/{member_id}", status_code=204)

--- a/app/orgs/service.py
+++ b/app/orgs/service.py
@@ -11,32 +11,20 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.org_membership import OrgMembership
-from app.models.user import User
 
 
 async def list_org_members(
     db: AsyncSession,
     org_id: uuid.UUID,
-) -> list[dict]:
-    """List all members of an org with their user email."""
+) -> list[OrgMembership]:
+    """List all members of an org (with user relationship loaded)."""
     stmt = (
-        select(OrgMembership, User.email)
-        .join(User, OrgMembership.user_id == User.id)
+        select(OrgMembership)
         .where(OrgMembership.org_id == org_id)
         .order_by(OrgMembership.joined_at)
     )
     result = await db.execute(stmt)
-    return [
-        {
-            "id": m.id,
-            "user_id": m.user_id,
-            "email": email,
-            "org_role": m.org_role,
-            "is_active": m.is_active,
-            "joined_at": m.joined_at,
-        }
-        for m, email in result.all()
-    ]
+    return list(result.scalars().all())
 
 
 async def get_membership_by_id(
@@ -85,6 +73,7 @@ async def create_membership(
     )
     db.add(membership)
     await db.flush()
+    await db.refresh(membership, ["user"])
     return membership
 
 

--- a/app/products/routes.py
+++ b/app/products/routes.py
@@ -5,7 +5,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.orgs.deps import get_current_org_membership, require_org_role
+from app.orgs.deps import get_current_org_membership, RequireOrgRole
 from app.core.database import get_db
 from app.models.org_membership import OrgMembership
 from app.models.product import Product
@@ -105,7 +105,7 @@ async def update_product(
 @router.delete("/{product_id}", status_code=204)
 async def delete_product(
     product_id: uuid.UUID,
-    membership: OrgMembership = Depends(require_org_role("ORG_OWNER", "ORG_ADMIN")),
+    membership: OrgMembership = Depends(RequireOrgRole("ORG_OWNER", "ORG_ADMIN")),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Delete a product. Owner/Admin only."""

--- a/app/suppliers/routes.py
+++ b/app/suppliers/routes.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.orgs.deps import (
     get_current_org_membership,
-    require_org_role,
+    RequireOrgRole,
 )
 from app.core.database import get_db
 from app.models.org_membership import OrgMembership
@@ -97,7 +97,7 @@ async def update_supplier(
 @router.delete("/{supplier_id}", status_code=204)
 async def delete_supplier(
     supplier_id: uuid.UUID,
-    membership: OrgMembership = Depends(require_org_role("ORG_OWNER", "ORG_ADMIN")),
+    membership: OrgMembership = Depends(RequireOrgRole("ORG_OWNER", "ORG_ADMIN")),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Delete a supplier. Owner/Admin only."""

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,852 @@
+# API Reference
+
+Complete reference for every endpoint in the EasyInventory API. All routes return JSON.
+
+> **Interactive docs:** When the API is running, visit `http://localhost:8000/docs` (Swagger UI) or `http://localhost:8000/redoc` (ReDoc) for auto-generated, interactive documentation.
+
+---
+
+## Table of Contents
+
+- [Authentication](#authentication)
+- [Common Headers](#common-headers)
+- [Error Format](#error-format)
+- [Health](#health)
+- [Auth](#auth)
+- [Organizations](#organizations)
+- [Suppliers](#suppliers)
+- [Products](#products)
+- [Product–Supplier Links](#productsupplier-links)
+- [Admin: Organizations](#admin-organizations)
+- [Admin: Users](#admin-users)
+- [Invite Flow Details](#invite-flow-details)
+
+---
+
+## Authentication
+
+Most endpoints require a valid JWT access token from AWS Cognito in the `Authorization` header:
+
+```
+Authorization: Bearer <access_token>
+```
+
+Tokens are obtained by signing in through the Cognito Hosted UI or SDK. See [cognito-setup.md](cognito-setup.md) for Cognito configuration details.
+
+**Unauthenticated endpoints:** Only `GET /health` is public.
+
+---
+
+## Common Headers
+
+| Header | Required | Description |
+|---|---|---|
+| `Authorization` | Yes (all except `/health`) | `Bearer <jwt_access_token>` |
+| `X-Org-Id` | Optional | UUID of the organization to scope the request to. If omitted, uses the user's most recently joined active org. |
+| `Content-Type` | For POST/PUT/PATCH | `application/json` |
+
+---
+
+## Error Format
+
+All errors return a JSON object with a `detail` field:
+
+```json
+{
+  "detail": "Human-readable error message"
+}
+```
+
+### Common Status Codes
+
+| Code | Meaning |
+|---|---|
+| `200` | Success |
+| `201` | Created |
+| `204` | No Content (successful deletion) |
+| `400` | Bad request / validation error / business rule violation |
+| `401` | Missing or invalid JWT token |
+| `403` | Insufficient permissions |
+| `404` | Resource not found |
+| `409` | Conflict (duplicate resource) |
+| `422` | Validation error (Pydantic) |
+| `500` | Internal server error |
+
+---
+
+## Health
+
+### `GET /health`
+
+Health check endpoint. No authentication required.
+
+**Response** `200`
+
+```json
+{
+  "status": "healthy",
+  "service": "easyinventory-api"
+}
+```
+
+---
+
+## Auth
+
+### `GET /api/me`
+
+Returns the current authenticated user's profile. On the very first call, automatically creates the user record in the database from the JWT claims.
+
+**Auth:** Required  
+**Response** `200`
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "email": "user@example.com",
+  "system_role": "SYSTEM_USER",
+  "is_active": true,
+  "created_at": "2024-01-15T10:30:00Z"
+}
+```
+
+---
+
+## Organizations
+
+All organization endpoints require authentication. Org-scoped endpoints use the `X-Org-Id` header or fall back to the user's default org.
+
+### `GET /api/orgs/me`
+
+Returns all of the current user's active organization memberships.
+
+**Auth:** Required  
+**Response** `200`
+
+```json
+[
+  {
+    "id": "membership-uuid",
+    "org_id": "org-uuid",
+    "org_role": "ORG_OWNER",
+    "is_active": true,
+    "joined_at": "2024-01-15T10:30:00Z",
+    "organization": {
+      "id": "org-uuid",
+      "name": "My Organization",
+      "created_at": "2024-01-15T10:30:00Z"
+    }
+  }
+]
+```
+
+---
+
+### `GET /api/orgs/members`
+
+Lists all members of the current organization.
+
+**Auth:** Required — any org member  
+**Response** `200`
+
+```json
+[
+  {
+    "id": "membership-uuid",
+    "user_id": "user-uuid",
+    "email": "owner@example.com",
+    "org_role": "ORG_OWNER",
+    "is_active": true,
+    "joined_at": "2024-01-15T10:30:00Z"
+  },
+  {
+    "id": "membership-uuid",
+    "user_id": "user-uuid",
+    "email": "employee@example.com",
+    "org_role": "ORG_EMPLOYEE",
+    "is_active": true,
+    "joined_at": "2024-02-01T09:00:00Z"
+  }
+]
+```
+
+---
+
+### `POST /api/orgs/invite`
+
+Invites a user to the current organization by email. See [Invite Flow Details](#invite-flow-details) for how the three invite scenarios work.
+
+**Auth:** Required — `ORG_OWNER` or `ORG_ADMIN`  
+**Request Body**
+
+```json
+{
+  "email": "newmember@example.com",
+  "org_role": "ORG_EMPLOYEE"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `email` | string (email) | Yes | — | Email address of the person to invite |
+| `org_role` | string | No | `"ORG_EMPLOYEE"` | One of: `ORG_ADMIN`, `ORG_EMPLOYEE`, `ORG_VIEWER` |
+
+**Permission rules:**
+- Owners can assign `ORG_ADMIN`, `ORG_EMPLOYEE`, or `ORG_VIEWER`.
+- Admins can only assign `ORG_EMPLOYEE` or `ORG_VIEWER` (not `ORG_ADMIN`).
+- `ORG_OWNER` cannot be assigned via invite — use the ownership transfer endpoint.
+
+**Response** `201`
+
+```json
+{
+  "id": "membership-uuid",
+  "user_id": "user-uuid",
+  "email": "newmember@example.com",
+  "org_role": "ORG_EMPLOYEE",
+  "is_active": true,
+  "joined_at": "2024-02-10T14:00:00Z"
+}
+```
+
+**Errors:**
+- `400` — User is already a member, or invalid role.
+- `403` — Caller lacks permission to assign the requested role.
+
+---
+
+### `PATCH /api/orgs/members/{member_id}/role`
+
+Changes a member's role within the organization.
+
+**Auth:** Required — `ORG_OWNER` or `ORG_ADMIN`  
+**Path:** `member_id` — the UUID of the **membership** (not the user)  
+**Request Body**
+
+```json
+{
+  "org_role": "ORG_ADMIN"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `org_role` | string | Yes | New role: `ORG_ADMIN`, `ORG_EMPLOYEE`, or `ORG_VIEWER` |
+
+**Permission rules:**
+- The org owner's role **cannot** be changed by anyone.
+- Only the owner can change an admin's role.
+- Admins can only change roles of employees and viewers.
+- The target role must be one the caller is allowed to assign.
+
+**Response** `200` — Updated member details (same shape as invite response)
+
+**Errors:**
+- `403` — Owner protected, admin hierarchy violation, or insufficient permission.
+- `404` — Membership not found.
+
+---
+
+### `PATCH /api/orgs/members/{member_id}/deactivate`
+
+Deactivates a member. They lose access but their membership record is preserved and can be reactivated later.
+
+**Auth:** Required — `ORG_OWNER` or `ORG_ADMIN`  
+**Path:** `member_id` — membership UUID  
+**Request Body:** None
+
+**Permission rules:**
+- The owner cannot be deactivated.
+- Only the owner can deactivate admins.
+
+**Response** `200` — Updated member details with `"is_active": false`
+
+---
+
+### `PATCH /api/orgs/members/{member_id}/activate`
+
+Reactivates a previously deactivated member.
+
+**Auth:** Required — `ORG_OWNER` or `ORG_ADMIN`  
+**Path:** `member_id` — membership UUID  
+**Request Body:** None
+
+**Response** `200` — Updated member details with `"is_active": true`
+
+---
+
+### `DELETE /api/orgs/members/{member_id}`
+
+Permanently removes a member from the organization.
+
+**Auth:** Required — `ORG_OWNER` or `ORG_ADMIN`  
+**Path:** `member_id` — membership UUID  
+**Request Body:** None
+
+**Permission rules:**
+- The owner cannot be removed.
+- Only the owner can remove admins.
+
+**Response** `204` — No content
+
+---
+
+## Suppliers
+
+All supplier endpoints are org-scoped. The organization is determined by the authenticated user's membership (or the `X-Org-Id` header).
+
+### `GET /api/suppliers`
+
+Lists all suppliers for the current organization.
+
+**Auth:** Required — any org member  
+**Response** `200`
+
+```json
+[
+  {
+    "id": "supplier-uuid",
+    "org_id": "org-uuid",
+    "name": "Fresh Farms Produce",
+    "contact_name": "Sarah Johnson",
+    "contact_email": "sarah@freshfarms.example.com",
+    "contact_phone": "555-0101",
+    "notes": "Organic produce specialist",
+    "created_at": "2024-01-15T10:30:00Z",
+    "updated_at": "2024-01-15T10:30:00Z"
+  }
+]
+```
+
+---
+
+### `GET /api/suppliers/{supplier_id}`
+
+Returns a single supplier by ID.
+
+**Auth:** Required — any org member  
+**Response** `200` — Single supplier object (same shape as list items)
+
+**Errors:**
+- `404` — Supplier not found in the current org.
+
+---
+
+### `POST /api/suppliers`
+
+Creates a new supplier.
+
+**Auth:** Required — any org member  
+**Request Body**
+
+```json
+{
+  "name": "Pacific Coast Seafood",
+  "contact_name": "Mike Chen",
+  "contact_email": "mike@pacificseafood.example.com",
+  "contact_phone": "555-0102",
+  "notes": "Delivers fresh seafood Mon/Wed/Fri"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Supplier name |
+| `contact_name` | string | No | Primary contact person |
+| `contact_email` | string (email) | No | Contact email |
+| `contact_phone` | string | No | Contact phone number |
+| `notes` | string | No | Free-text notes |
+
+**Response** `201` — The created supplier object
+
+---
+
+### `PUT /api/suppliers/{supplier_id}`
+
+Updates an existing supplier. All fields are optional — only provided fields are updated.
+
+**Auth:** Required — any org member  
+**Request Body**
+
+```json
+{
+  "name": "Pacific Coast Seafood LLC",
+  "notes": "Updated delivery schedule: Mon-Fri"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | No | Updated name |
+| `contact_name` | string | No | Updated contact person |
+| `contact_email` | string (email) | No | Updated email |
+| `contact_phone` | string | No | Updated phone |
+| `notes` | string | No | Updated notes |
+
+**Response** `200` — The updated supplier object
+
+**Errors:**
+- `404` — Supplier not found in the current org.
+
+---
+
+### `DELETE /api/suppliers/{supplier_id}`
+
+Deletes a supplier. This also removes any product-supplier links associated with this supplier.
+
+**Auth:** Required — `ORG_OWNER` or `ORG_ADMIN`  
+**Response** `204` — No content
+
+**Errors:**
+- `404` — Supplier not found in the current org.
+
+---
+
+## Products
+
+All product endpoints are org-scoped.
+
+### `GET /api/products`
+
+Lists all products for the current organization. Returns a lightweight response **without** nested supplier information (for performance on large lists).
+
+**Auth:** Required — any org member  
+**Response** `200`
+
+```json
+[
+  {
+    "id": "product-uuid",
+    "org_id": "org-uuid",
+    "name": "Organic Apples",
+    "description": "Fresh organic Gala apples",
+    "sku": "PROD-001",
+    "category": "Produce",
+    "created_at": "2024-01-15T10:30:00Z",
+    "updated_at": "2024-01-15T10:30:00Z"
+  }
+]
+```
+
+---
+
+### `GET /api/products/{product_id}`
+
+Returns a single product by ID, **including** its linked suppliers.
+
+**Auth:** Required — any org member  
+**Response** `200`
+
+```json
+{
+  "id": "product-uuid",
+  "org_id": "org-uuid",
+  "name": "Organic Apples",
+  "description": "Fresh organic Gala apples",
+  "sku": "PROD-001",
+  "category": "Produce",
+  "created_at": "2024-01-15T10:30:00Z",
+  "updated_at": "2024-01-15T10:30:00Z",
+  "product_suppliers": [
+    {
+      "id": "link-uuid",
+      "supplier_id": "supplier-uuid",
+      "supplier_name": "Fresh Farms Produce",
+      "is_active": true,
+      "created_at": "2024-01-20T08:00:00Z",
+      "updated_at": "2024-01-20T08:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+### `POST /api/products`
+
+Creates a new product.
+
+**Auth:** Required — any org member  
+**Request Body**
+
+```json
+{
+  "name": "Organic Apples",
+  "description": "Fresh organic Gala apples",
+  "sku": "PROD-001",
+  "category": "Produce"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Product name |
+| `description` | string | No | Product description |
+| `sku` | string | No | Stock keeping unit |
+| `category` | string | No | Product category |
+
+**Response** `201` — The created product (with empty `product_suppliers` array)
+
+---
+
+### `PUT /api/products/{product_id}`
+
+Updates a product's details. All fields are optional.
+
+**Auth:** Required — any org member  
+**Request Body**
+
+```json
+{
+  "name": "Organic Gala Apples",
+  "category": "Fresh Produce"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | No | Updated name |
+| `description` | string | No | Updated description |
+| `sku` | string | No | Updated SKU |
+| `category` | string | No | Updated category |
+
+**Response** `200` — The updated product (with nested suppliers)
+
+---
+
+### `DELETE /api/products/{product_id}`
+
+Deletes a product and all its supplier links.
+
+**Auth:** Required — `ORG_OWNER` or `ORG_ADMIN`  
+**Response** `204` — No content
+
+---
+
+## Product–Supplier Links
+
+These endpoints manage the many-to-many relationship between products and suppliers. Both the product and supplier must belong to the same organization.
+
+### `GET /api/products/{product_id}/suppliers`
+
+Lists all suppliers linked to a specific product.
+
+**Auth:** Required — any org member  
+**Response** `200`
+
+```json
+[
+  {
+    "id": "link-uuid",
+    "product_id": "product-uuid",
+    "supplier_id": "supplier-uuid",
+    "supplier_name": "Fresh Farms Produce",
+    "is_active": true,
+    "created_at": "2024-01-20T08:00:00Z",
+    "updated_at": "2024-01-20T08:00:00Z"
+  }
+]
+```
+
+---
+
+### `POST /api/products/{product_id}/suppliers`
+
+Links a supplier to a product.
+
+**Auth:** Required — any org member  
+**Request Body**
+
+```json
+{
+  "supplier_id": "supplier-uuid"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `supplier_id` | UUID | Yes | ID of the supplier to link |
+
+**Response** `201` — The created link
+
+**Errors:**
+- `404` — Product or supplier not found in the current org.
+- `409` — Supplier is already linked to this product.
+
+---
+
+### `PATCH /api/products/{product_id}/suppliers/{supplier_id}`
+
+Updates the `is_active` flag on a product-supplier link. Use this to temporarily disable a supplier for a product without removing the link entirely.
+
+**Auth:** Required — any org member  
+**Request Body**
+
+```json
+{
+  "is_active": false
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `is_active` | boolean | Yes | Whether the link is active |
+
+**Response** `200` — The updated link
+
+**Errors:**
+- `404` — Link not found (product and supplier are not linked).
+
+---
+
+### `DELETE /api/products/{product_id}/suppliers/{supplier_id}`
+
+Permanently removes a supplier link from a product.
+
+**Auth:** Required — any org member  
+**Response** `204` — No content
+
+**Errors:**
+- `404` — Link not found.
+
+---
+
+## Admin: Organizations
+
+System-admin endpoints for managing organizations globally. All endpoints require `SYSTEM_ADMIN` system role.
+
+### `GET /api/admin/status`
+
+Verifies the caller has system admin access.
+
+**Auth:** Required — `SYSTEM_ADMIN`  
+**Response** `200`
+
+```json
+{
+  "message": "You are an admin",
+  "email": "admin@example.com",
+  "role": "SYSTEM_ADMIN"
+}
+```
+
+---
+
+### `POST /api/admin/orgs`
+
+Creates a new organization and assigns an owner. If the owner email doesn't exist in the system, a Cognito invite is sent and a placeholder user is created.
+
+**Auth:** Required — `SYSTEM_ADMIN`  
+**Request Body**
+
+```json
+{
+  "name": "Acme Corporation",
+  "owner_email": "owner@acme.example.com"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Organization name |
+| `owner_email` | string (email) | Yes | Email of the person who will own the org |
+
+**Response** `201`
+
+```json
+{
+  "id": "org-uuid",
+  "name": "Acme Corporation",
+  "created_at": "2024-01-15T10:30:00Z",
+  "owner_email": "owner@acme.example.com",
+  "member_count": 1
+}
+```
+
+---
+
+### `GET /api/admin/orgs`
+
+Lists all organizations with owner email and member count.
+
+**Auth:** Required — `SYSTEM_ADMIN`  
+**Response** `200`
+
+```json
+[
+  {
+    "id": "org-uuid",
+    "name": "Acme Corporation",
+    "created_at": "2024-01-15T10:30:00Z",
+    "owner_email": "owner@acme.example.com",
+    "member_count": 5
+  }
+]
+```
+
+---
+
+### `PATCH /api/admin/orgs/{org_id}`
+
+Renames an organization.
+
+**Auth:** Required — `SYSTEM_ADMIN`  
+**Request Body**
+
+```json
+{
+  "name": "Acme Corp (Renamed)"
+}
+```
+
+**Response** `200` — The updated org (same shape as list items)
+
+---
+
+### `DELETE /api/admin/orgs/{org_id}`
+
+Deletes an organization and all its memberships.
+
+**Auth:** Required — `SYSTEM_ADMIN`  
+**Response** `204` — No content
+
+---
+
+### `POST /api/admin/orgs/{org_id}/transfer-ownership`
+
+Transfers ownership of an organization to another member.
+
+**Auth:** Required — `SYSTEM_ADMIN`  
+**Request Body**
+
+```json
+{
+  "new_owner_email": "newowner@example.com"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `new_owner_email` | string (email) | Yes | Email of the new owner (must be an existing member) |
+
+**Response** `200`
+
+```json
+{
+  "id": "membership-uuid",
+  "user_id": "user-uuid",
+  "email": "newowner@example.com",
+  "org_role": "ORG_OWNER",
+  "is_active": true,
+  "joined_at": "2024-01-15T10:30:00Z"
+}
+```
+
+---
+
+### `GET /api/admin/orgs/{org_id}/members`
+
+Lists all members of a specific organization.
+
+**Auth:** Required — `SYSTEM_ADMIN`  
+**Response** `200` — Array of member details (same shape as `GET /api/orgs/members`)
+
+---
+
+## Admin: Users
+
+System-admin endpoints for managing users globally.
+
+### `GET /api/admin/users`
+
+Lists all users across all organizations.
+
+**Auth:** Required — `SYSTEM_ADMIN`  
+**Response** `200`
+
+```json
+[
+  {
+    "id": "user-uuid",
+    "email": "user@example.com",
+    "system_role": "SYSTEM_USER",
+    "is_active": true,
+    "created_at": "2024-01-15T10:30:00Z",
+    "org_count": 2
+  }
+]
+```
+
+---
+
+### `DELETE /api/admin/users/{user_id}`
+
+Deletes a user from both the local database and AWS Cognito. Removes all their org memberships.
+
+**Auth:** Required — `SYSTEM_ADMIN`  
+**Response** `204` — No content
+
+**Errors:**
+- `400` — You cannot delete your own account.
+- `404` — User not found.
+
+---
+
+## Invite Flow Details
+
+The invite system handles three scenarios transparently:
+
+### Scenario 1: Known user, not yet a member
+
+The invited email belongs to someone who already has an account (they've logged in at least once).
+
+1. API finds the existing `User` record by email.
+2. Creates an **active** `OrgMembership` linking the user to the organization.
+3. The user can immediately access the org — no further action needed.
+
+### Scenario 2: Known user, already a member
+
+The email belongs to someone who is already a member (active or pending) of this organization.
+
+- API raises `AlreadyExists` with an appropriate message.
+- **Status:** `400`
+
+### Scenario 3: Unknown user (new invite)
+
+The email doesn't exist in the local database.
+
+1. API calls **Cognito `AdminCreateUser`** — Cognito sends an email invitation with a temporary password.
+2. API creates a **placeholder** `User` record in the local database (has email but no `cognito_sub`).
+3. API creates an **inactive** `OrgMembership` (the user hasn't accepted yet).
+4. When the user accepts the Cognito invite and makes their first API call:
+   - The `get_current_user` dependency matches their `email` to the placeholder.
+   - The placeholder is **claimed** — `cognito_sub` is set from the JWT.
+   - All inactive memberships are **activated**.
+
+### Visual flow
+
+```
+Org Admin invites "alice@co.example"
+    │
+    ├─ User table has alice@co.example?
+    │   ├─ YES: Already a member?
+    │   │    ├─ YES → 400 AlreadyExists
+    │   │    └─ NO  → Create active membership → 201 ✓
+    │   │
+    │   └─ NO: Unknown user
+    │        ├─ Cognito AdminCreateUser (sends email invite)
+    │        ├─ Create placeholder User (no cognito_sub)
+    │        └─ Create inactive membership → 201 ✓
+    │
+    │  (Later, when Alice signs up and calls /api/me)
+    │        ├─ Match email → claim placeholder (set cognito_sub)
+    │        └─ Activate all inactive memberships
+```
+
+---
+
+## Related Guides
+
+- [Architecture](architecture.md) — System design, request lifecycle, RBAC
+- [Developer Guide](developer-guide.md) — Adding new endpoints
+- [Getting Started](getting-started.md) — Setup and installation

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,12 +39,12 @@ easyinventory-api/
 │   ├── auth/                    # Authentication domain (AWS Cognito)
 │   │   ├── cognito_token.py     #   JWKS fetching, JWT verification (runs on every request)
 │   │   ├── cognito_admin.py     #   Cognito admin ops: invite user, delete user (cold path)
-│   │   ├── deps.py              #   FastAPI dependencies: get_current_user, require_role
+│   │   ├── deps.py              #   FastAPI dependencies: get_current_user, RequireRole
 │   │   ├── routes.py            #   GET /api/me
 │   │   └── schemas.py           #   UserResponse schema
 │   │
 │   ├── orgs/                    # Organization management domain
-│   │   ├── deps.py              #   get_current_org_membership, require_org_role dependencies
+│   │   ├── deps.py              #   get_current_org_membership, RequireOrgRole dependencies
 │   │   ├── permissions.py       #   Permission assertion helpers (raise domain exceptions)
 │   │   ├── routes.py            #   Member list, invite, role change, activate/deactivate
 │   │   ├── schemas.py           #   Org-related Pydantic schemas
@@ -308,7 +308,7 @@ The application uses **AWS Cognito** for user authentication. Users sign up and 
 |---|---|---|
 | `app/auth/cognito_token.py` | Fetches JWKS, verifies JWT signature/claims | **Every authenticated request** (hot path) |
 | `app/auth/cognito_admin.py` | Creates Cognito accounts for invitees, deletes users | Only during invite/delete operations (cold path) |
-| `app/auth/deps.py` | FastAPI dependencies: `get_current_user`, `require_role` | Every authenticated endpoint |
+| `app/auth/deps.py` | FastAPI dependencies: `get_current_user`, `RequireRole` | Every authenticated endpoint |
 
 ### JWKS caching
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,10 +51,10 @@ easyinventory-api/
 │   │   └── service.py           #   Member CRUD (pure database operations)
 │   │
 │   ├── admin/                   # System admin domain (SYSTEM_ADMIN only)
-│   │   ├── routes_orgs.py       #   Org CRUD, ownership transfer, member introspection
-│   │   ├── routes_users.py      #   User listing and deletion (DB + Cognito)
+│   │   ├── routes_orgs.py       #   Org CRUD, ownership transfer, member introspection (delegates to service)
+│   │   ├── routes_users.py      #   User listing and deletion (delegates to service + Cognito)
 │   │   ├── schemas.py           #   Admin-specific schemas
-│   │   └── service.py           #   System-admin database operations
+│   │   └── service.py           #   Aggregate queries, org/user CRUD, dataclasses for query results
 │   │
 │   ├── products/                # Products domain
 │   │   ├── routes.py            #   Product CRUD + product-supplier link endpoints
@@ -140,7 +140,7 @@ Every feature domain in the `app/` directory follows the same **3-file pattern**
 |---|---|---|
 | `routes.py` | HTTP endpoint definitions. Parses requests, wires auth dependencies, serializes responses. | HTTP, FastAPI, Pydantic schemas |
 | `schemas.py` | Pydantic models for request bodies and response shapes. Handles validation and serialization. | Pydantic only |
-| `service.py` | Pure database operations. Accepts a `db` session, returns ORM model instances. **Never raises HTTP exceptions.** | SQLAlchemy, ORM models, domain exceptions |
+| `service.py` | Pure database operations. Accepts a `db` session, returns ORM model instances or domain-specific dataclasses. **Never raises HTTP exceptions.** | SQLAlchemy, ORM models, domain exceptions |
 
 ### Why this separation matters
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -389,7 +389,7 @@ async def list_suppliers(
 # Only owners and admins can delete
 @router.delete("/api/suppliers/{id}")
 async def delete_supplier(
-    membership: OrgMembership = Depends(require_org_role("ORG_OWNER", "ORG_ADMIN")),
+    membership: OrgMembership = Depends(RequireOrgRole("ORG_OWNER", "ORG_ADMIN")),
     ...
 )
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,637 @@
+# Architecture Guide
+
+A deep dive into how the EasyInventory API is structured, how requests flow through the system, and how the major subsystems (authentication, authorization, database, exceptions) work together.
+
+---
+
+## Table of Contents
+
+- [Project Structure](#project-structure)
+- [Domain Module Pattern](#domain-module-pattern)
+- [Architecture Overview](#architecture-overview)
+- [Request Lifecycle](#request-lifecycle)
+- [Multi-Tenancy](#multi-tenancy)
+- [Authentication (AWS Cognito)](#authentication-aws-cognito)
+- [Role-Based Access Control (RBAC)](#role-based-access-control-rbac)
+- [Database & Models](#database--models)
+- [Database Migrations (Alembic)](#database-migrations-alembic)
+- [Domain Exception System](#domain-exception-system)
+- [Bootstrap & Seed Data](#bootstrap--seed-data)
+
+---
+
+## Project Structure
+
+```
+easyinventory-api/
+├── app/                         # All application source code
+│   ├── main.py                  # App factory: creates FastAPI app, registers middleware,
+│   │                            #   exception handlers, CORS, and all route modules
+│   ├── __init__.py
+│   │
+│   ├── core/                    # Shared infrastructure (used by all domains)
+│   │   ├── config.py            #   pydantic-settings: loads env vars into Settings class
+│   │   ├── database.py          #   SQLAlchemy async engine, session factory, get_db dependency
+│   │   ├── exceptions.py        #   Domain exception hierarchy (AppError and subclasses)
+│   │   ├── middleware.py        #   Request logging, correlation IDs, JSON formatter
+│   │   └── roles.py            #   SystemRole / OrgRole string constants
+│   │
+│   ├── auth/                    # Authentication domain (AWS Cognito)
+│   │   ├── cognito_token.py     #   JWKS fetching, JWT verification (runs on every request)
+│   │   ├── cognito_admin.py     #   Cognito admin ops: invite user, delete user (cold path)
+│   │   ├── deps.py              #   FastAPI dependencies: get_current_user, require_role
+│   │   ├── routes.py            #   GET /api/me
+│   │   └── schemas.py           #   UserResponse schema
+│   │
+│   ├── orgs/                    # Organization management domain
+│   │   ├── deps.py              #   get_current_org_membership, require_org_role dependencies
+│   │   ├── permissions.py       #   Permission assertion helpers (raise domain exceptions)
+│   │   ├── routes.py            #   Member list, invite, role change, activate/deactivate
+│   │   ├── schemas.py           #   Org-related Pydantic schemas
+│   │   └── service.py           #   Member CRUD (pure database operations)
+│   │
+│   ├── admin/                   # System admin domain (SYSTEM_ADMIN only)
+│   │   ├── routes_orgs.py       #   Org CRUD, ownership transfer, member introspection
+│   │   ├── routes_users.py      #   User listing and deletion (DB + Cognito)
+│   │   ├── schemas.py           #   Admin-specific schemas
+│   │   └── service.py           #   System-admin database operations
+│   │
+│   ├── products/                # Products domain
+│   │   ├── routes.py            #   Product CRUD + product-supplier link endpoints
+│   │   ├── schemas.py           #   Product Pydantic schemas
+│   │   └── service.py           #   Product data access
+│   │
+│   ├── suppliers/               # Suppliers domain
+│   │   ├── routes.py            #   Supplier CRUD endpoints
+│   │   ├── schemas.py           #   Supplier Pydantic schemas
+│   │   └── service.py           #   Supplier data access
+│   │
+│   ├── users/                   # User lifecycle domain
+│   │   └── service.py           #   get_or_create_user, placeholder claiming, deletion
+│   │
+│   ├── invites/                 # Invite orchestration domain
+│   │   └── service.py           #   invite_user_to_org (coordinates Cognito + DB)
+│   │
+│   ├── bootstrap/               # Startup seeding
+│   │   ├── seeder.py            #   run_bootstrap (idempotent admin + org creation)
+│   │   └── seed_data.py         #   Example suppliers, products, and links
+│   │
+│   ├── health/                  # Health check
+│   │   └── routes.py            #   GET /health
+│   │
+│   └── models/                  # SQLAlchemy ORM models
+│       ├── base.py              #   Abstract base (UUID pk + created_at)
+│       ├── user.py              #   User (cognito_sub, email, system_role)
+│       ├── organization.py      #   Organization (name)
+│       ├── org_membership.py    #   OrgMembership (user <-> org, role, active status)
+│       ├── supplier.py          #   Supplier (org-scoped, contact info)
+│       ├── product.py           #   Product (org-scoped, SKU, category)
+│       └── product_supplier.py  #   ProductSupplier join table (is_active flag)
+│
+├── alembic/                     # Database migration infrastructure
+│   ├── env.py                   #   Async migration runner (reads DATABASE_URL)
+│   └── versions/                #   Auto-generated migration files
+│
+├── tests/                       # Test suite 1: mocked database (fast, no Postgres needed)
+│   ├── conftest.py              #   App + httpx client fixtures
+│   ├── unit/                    #   Pure logic tests (no HTTP, no real DB)
+│   └── functional/              #   HTTP endpoint tests via async test client
+│
+├── testsv2/                     # Test suite 2: real database (transaction-per-test rollback)
+│   ├── conftest.py              #   DB engine, session, transaction rollback fixtures
+│   ├── factories.py             #   Factory functions that INSERT real rows
+│   ├── integration/             #   Service-layer tests against real Postgres
+│   └── functional/              #   HTTP endpoint tests against real Postgres
+│       └── conftest.py          #   Auth bypass fixture (no Cognito needed in tests)
+│
+├── docs/                        # Documentation (you are here)
+│   ├── getting-started.md       #   Setup and installation guide
+│   ├── architecture.md          #   This file
+│   ├── api-reference.md         #   All API endpoints
+│   ├── developer-guide.md       #   Contributing, testing, coding standards
+│   ├── deployment-guide.md      #   Production deployment
+│   ├── troubleshooting.md       #   Common issues and fixes
+│   └── cognito-setup.md         #   Cognito User Pool setup
+│
+├── Dockerfile                   # Dev Docker image (Python 3.11, Uvicorn)
+├── Dockerfile.api               # Prod Docker image (Python 3.12, Gunicorn + Uvicorn)
+├── docker-compose.yml           # Dev: API + Postgres
+├── docker-compose.prod.yml      # Prod: API + Postgres + Web + Caddy (HTTPS)
+├── Caddyfile                    # Caddy reverse proxy config (auto-HTTPS)
+├── Makefile                     # Developer command shortcuts
+├── build-and-push.sh            # Build + push Docker images to ECR
+├── deploy.sh                    # Pull and restart on production server
+├── requirements.txt             # Runtime Python dependencies
+├── dev-requirements.txt         # Runtime + dev dependencies (includes tests, linting)
+├── pyproject.toml               # Black config, pytest config, project metadata
+├── mypy.ini                     # Type checking configuration
+├── alembic.ini                  # Alembic migration config
+├── run.py                       # Entry point: uvicorn app.main:app --reload
+└── .env.example                 # Template for environment variables
+```
+
+---
+
+## Domain Module Pattern
+
+Every feature domain in the `app/` directory follows the same **3-file pattern**:
+
+| File | Responsibility | Knows About |
+|---|---|---|
+| `routes.py` | HTTP endpoint definitions. Parses requests, wires auth dependencies, serializes responses. | HTTP, FastAPI, Pydantic schemas |
+| `schemas.py` | Pydantic models for request bodies and response shapes. Handles validation and serialization. | Pydantic only |
+| `service.py` | Pure database operations. Accepts a `db` session, returns ORM model instances. **Never raises HTTP exceptions.** | SQLAlchemy, ORM models, domain exceptions |
+
+### Why this separation matters
+
+- **Testability:** Service functions can be unit-tested with a mocked `db` session — no HTTP layer needed.
+- **Reusability:** Services can be called from background jobs, CLI scripts, management commands, or other services without importing FastAPI.
+- **Clarity:** Each file has a single responsibility. If you need to change how data is stored, you only touch `service.py`. If you need to change the API contract, you only touch `routes.py` and `schemas.py`.
+
+### Dependency flow
+
+```
+routes.py  →  service.py  →  SQLAlchemy models
+    ↓              ↓
+schemas.py    exceptions.py
+```
+
+Routes depend on services and schemas. Services depend on models and exceptions. **Services never import from routes or schemas.**
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Caddy (Production only)                   │
+│           Automatic HTTPS · Reverse Proxy                   │
+│  <your-domain>        ->  web:3000  (frontend)              │
+│  api.<your-domain>    ->  api:8000  (this API)              │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                    ┌──────▼──────┐
+                    │   FastAPI   │
+                    │   (API)     │
+                    └──────┬──────┘
+                           │
+         ┌─────────────────┼─────────────────┐
+         │                 │                 │
+   ┌─────▼─────┐   ┌──────▼──────┐   ┌──────▼───────┐
+   │  AWS       │   │ PostgreSQL  │   │  CloudWatch  │
+   │  Cognito   │   │   (DB)      │   │  (Logging)   │
+   │  (Auth)    │   │             │   │              │
+   └───────────┘   └─────────────┘   └──────────────┘
+```
+
+### Components
+
+| Component | Role | Details |
+|---|---|---|
+| **FastAPI** | Web framework | Handles HTTP requests, routing, validation, serialization |
+| **PostgreSQL 16** | Data storage | All application data — users, orgs, products, suppliers |
+| **AWS Cognito** | Authentication | User sign-up/sign-in, JWT token issuance |
+| **Caddy** | Reverse proxy (prod) | Automatic HTTPS via Let's Encrypt, routes traffic to API and frontend |
+| **CloudWatch** | Logging (prod) | Centralized log aggregation via the `awslogs` Docker logging driver |
+
+---
+
+## Request Lifecycle
+
+Here's what happens step-by-step when an HTTP request hits the API:
+
+### 1. Middleware Layer
+
+The `RequestLoggingMiddleware` (defined in `app/core/middleware.py`) intercepts every request:
+
+- **Assigns a correlation ID** — Checks for an `X-Request-ID` header. If none exists, generates a UUID. This ID is included in all log messages for that request, making it easy to trace a single request through the logs.
+- **Logs the request** — Method, path, and timing information.
+- **Captures errors** — If the response is 4xx or 5xx, the middleware logs the response body for debugging.
+
+### 2. CORS
+
+FastAPI's `CORSMiddleware` validates the request's `Origin` header against the `CORS_ORIGINS` setting. Requests from unknown origins are rejected. This prevents unauthorized websites from calling the API.
+
+### 3. Authentication
+
+The `get_current_user` dependency (defined in `app/auth/deps.py`) runs on every authenticated endpoint:
+
+1. Extracts the JWT from the `Authorization: Bearer <token>` header.
+2. Fetches Cognito's public keys (JWKS) from `https://cognito-idp.{region}.amazonaws.com/{pool_id}/.well-known/jwks.json`. The JWKS is **cached** after the first fetch (no network call on subsequent requests).
+3. Validates the JWT: checks the signature, issuer, audience (`client_id`), and expiration.
+4. Extracts the `sub` (Cognito user ID) and `email` from the token claims.
+5. Looks up the user in the database by `cognito_sub`. If not found, creates a new `User` record (or claims an existing placeholder — see [Invite Flow](#placeholder-claiming)).
+
+### 4. Organization Resolution
+
+For org-scoped endpoints, the `get_current_org_membership` dependency (defined in `app/orgs/deps.py`) runs next:
+
+1. Checks for an `X-Org-Id` header — if present, uses that org.
+2. If no header, falls back to the user's **most recently joined active organization**.
+3. Verifies the user has an **active** membership in that org.
+4. Returns the `OrgMembership` object (which includes the user's role in this org).
+
+### 5. Route Handler
+
+The route function parses the request body using Pydantic schemas, calls the appropriate service function, and returns the result. The response is serialized automatically by FastAPI using the `response_model`.
+
+### 6. Service Layer
+
+Service functions execute database queries via SQLAlchemy. On validation or business rule failures, they raise **domain exceptions** (not HTTP exceptions).
+
+### 7. Exception Handler
+
+A custom exception handler in `app/main.py` catches all `AppError` subclasses and converts them to JSON HTTP responses with the appropriate status code.
+
+### 8. Response
+
+The JSON response is sent back to the client with headers including the `X-Request-ID` correlation ID.
+
+---
+
+## Multi-Tenancy
+
+EasyInventory is a **multi-tenant** application. Every piece of business data (suppliers, products, product-supplier links) belongs to an **organization**. Users can be members of multiple organizations.
+
+### How data isolation works
+
+1. **Every business table has an `org_id` column** — a foreign key to the `organizations` table.
+2. **Every service function receives an `org_id` parameter** — queries always include `WHERE org_id = :org_id`.
+3. **The `org_id` comes from the authenticated user's org membership** — resolved by the `get_current_org_membership` dependency. It is **never** taken from the request body.
+
+### Switching organizations
+
+Users who belong to multiple orgs can switch between them by including the `X-Org-Id` header in their requests:
+
+```
+GET /api/products
+Authorization: Bearer <token>
+X-Org-Id: 550e8400-e29b-41d4-a716-446655440000
+```
+
+If the header is omitted, the API uses the user's most recently joined active org.
+
+### Why this matters for developers
+
+When writing new service functions, **always filter by `org_id`**. Never return data from one org to a user in another org. The org membership dependency already provides the correct `org_id` — just pass it through.
+
+---
+
+## Authentication (AWS Cognito)
+
+The application uses **AWS Cognito** for user authentication. Users sign up and log in through Cognito, which issues JWT tokens. The API verifies these tokens on every authenticated request.
+
+### Authentication flow
+
+```
+┌──────────┐     ┌──────────┐     ┌──────────────┐
+│  Frontend │────>│  Cognito │────>│  Frontend    │
+│  (Login)  │     │  (Auth)  │     │  (Has token) │
+└──────────┘     └──────────┘     └──────┬───────┘
+                                         │
+                              Authorization: Bearer <jwt>
+                                         │
+                                  ┌──────▼───────┐
+                                  │   API        │
+                                  │  (Verifies)  │
+                                  └──────────────┘
+```
+
+1. **User signs in** via the frontend (Cognito Hosted UI or SDK) and receives a JWT access token.
+2. **Frontend sends requests** with the `Authorization: Bearer <token>` header.
+3. **API verifies the token** by checking the JWT signature against Cognito's public keys (JWKS), and validating the issuer, audience, and expiration.
+4. **User record is found or created** in the local database on first authenticated request.
+
+### Key files
+
+| File | What It Does | When It Runs |
+|---|---|---|
+| `app/auth/cognito_token.py` | Fetches JWKS, verifies JWT signature/claims | **Every authenticated request** (hot path) |
+| `app/auth/cognito_admin.py` | Creates Cognito accounts for invitees, deletes users | Only during invite/delete operations (cold path) |
+| `app/auth/deps.py` | FastAPI dependencies: `get_current_user`, `require_role` | Every authenticated endpoint |
+
+### JWKS caching
+
+The JWKS (JSON Web Key Set) is the set of public keys used to verify JWT signatures. The API fetches it once from Cognito on the first token verification, then caches it for the lifetime of the process. This means:
+
+- No network call to Cognito on most requests — just local JWT verification.
+- If Cognito rotates keys, restarting the API will fetch the new keys.
+
+### Placeholder claiming
+
+When a user is invited (before they have a Cognito account), a **placeholder** `User` record is created in the database with their email but no `cognito_sub`. When they sign up via Cognito and make their first API request:
+
+1. The API sees a valid JWT with a `sub` and `email`.
+2. It finds the placeholder user by email.
+3. It "claims" the placeholder by setting the `cognito_sub` field.
+4. All existing memberships (which were created during the invite) are activated.
+
+### Setup
+
+See [cognito-setup.md](cognito-setup.md) for the full Cognito User Pool configuration guide.
+
+---
+
+## Role-Based Access Control (RBAC)
+
+The application has a **two-level role system** defined in `app/core/roles.py`.
+
+### System Roles
+
+Applied at the **user** level. Controls access to system-wide admin features.
+
+| Role | Constant | Description |
+|---|---|---|
+| System Admin | `SystemRole.ADMIN` = `"SYSTEM_ADMIN"` | Can create organizations, manage all users, access `/api/admin/*` endpoints |
+| System User | `SystemRole.USER` = `"SYSTEM_USER"` | Default role for all regular users |
+
+### Organization Roles
+
+Applied **per-organization** via the `org_memberships` table. Controls what a user can do within a specific organization.
+
+| Role | Constant | Who Can Assign | Capabilities |
+|---|---|---|---|
+| Owner | `OrgRole.OWNER` = `"ORG_OWNER"` | System Admin only | Full control. Manage admins, employees, viewers. Cannot be demoted or removed. |
+| Admin | `OrgRole.ADMIN` = `"ORG_ADMIN"` | Owner only | Invite members, manage employees and viewers. Cannot manage other admins or the owner. |
+| Employee | `OrgRole.EMPLOYEE` = `"ORG_EMPLOYEE"` | Owner or Admin | View, create, and edit products and suppliers. Cannot delete resources or manage members. |
+| Viewer | `OrgRole.VIEWER` = `"ORG_VIEWER"` | Owner or Admin | Read-only access to products and suppliers. |
+
+### Permission rules
+
+These rules are enforced in `app/orgs/permissions.py`:
+
+- **Owner protection:** The org owner cannot be deactivated, removed, or have their role changed by anyone (including themselves). Ownership transfer requires a separate admin endpoint.
+- **Admin hierarchy:** Only the owner can modify admins (change role, deactivate, remove). Admins cannot manage other admins — they can only manage employees and viewers.
+- **Role assignment via invite:** Only `ORG_ADMIN`, `ORG_EMPLOYEE`, and `ORG_VIEWER` can be assigned during invite. `ORG_OWNER` requires ownership transfer.
+
+### Role groups (convenience constants)
+
+These are defined in `app/core/roles.py` and used throughout the codebase:
+
+```python
+OrgRole.ALL        = ("ORG_OWNER", "ORG_ADMIN", "ORG_EMPLOYEE", "ORG_VIEWER")
+OrgRole.INVITABLE  = ("ORG_ADMIN", "ORG_EMPLOYEE", "ORG_VIEWER")
+OrgRole.MANAGERS   = ("ORG_OWNER", "ORG_ADMIN")
+```
+
+### How roles are checked in routes
+
+Routes use FastAPI dependency injection:
+
+```python
+# Any org member can access this endpoint
+@router.get("/api/suppliers")
+async def list_suppliers(
+    membership: OrgMembership = Depends(get_current_org_membership),
+    ...
+)
+
+# Only owners and admins can delete
+@router.delete("/api/suppliers/{id}")
+async def delete_supplier(
+    membership: OrgMembership = Depends(require_org_role("ORG_OWNER", "ORG_ADMIN")),
+    ...
+)
+```
+
+---
+
+## Database & Models
+
+### Technology stack
+
+| Component | Technology | Purpose |
+|---|---|---|
+| Database | PostgreSQL 16 | Relational data storage |
+| ORM | SQLAlchemy 2.0 (async) | Object-relational mapping |
+| Driver | asyncpg | High-performance async Postgres driver |
+| Migrations | Alembic | Schema version control |
+
+### Database configuration
+
+The database layer is defined in `app/core/database.py`:
+
+- **`engine`** — Async SQLAlchemy engine created from the `DATABASE_URL` environment variable. When `DEBUG=true`, enables SQL query logging.
+- **`async_session`** — Session factory with `expire_on_commit=False` (prevents lazy load errors after commit).
+- **`get_db()`** — FastAPI dependency that yields a database session. Automatically commits on success and rolls back on error.
+
+### Base model
+
+All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which provides two common fields:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `id` | UUID | Auto-generated (`uuid4`) | Primary key |
+| `created_at` | DateTime (with timezone) | Server-side `now()` | Record creation timestamp |
+
+### Data models
+
+```
+┌──────────┐     ┌───────────────┐     ┌──────────────┐
+│   User   │────<│ OrgMembership │>────│ Organization │
+└──────────┘     └───────────────┘     └──────────────┘
+                                              │
+                              ┌───────────────┼───────────────┐
+                              │               │               │
+                        ┌─────▼────┐   ┌──────▼─────┐        │
+                        │ Supplier │   │  Product   │        │
+                        └─────┬────┘   └──────┬─────┘        │
+                              │               │               │
+                              └──────┐ ┌──────┘               │
+                              ┌──────▼─▼──────┐               │
+                              │ProductSupplier│               │
+                              └───────────────┘               │
+```
+
+| Model | Table | Key Fields | Relations |
+|---|---|---|---|
+| `User` | `users` | `cognito_sub` (unique), `email`, `system_role`, `is_active` | → `OrgMembership` (one-to-many) |
+| `Organization` | `organizations` | `name` | → `OrgMembership` (one-to-many) |
+| `OrgMembership` | `org_memberships` | `org_id` (FK), `user_id` (FK), `org_role`, `is_active` | → `User`, `Organization` |
+| `Supplier` | `suppliers` | `org_id` (FK), `name`, `contact_name`, `contact_email`, `contact_phone`, `notes` | — |
+| `Product` | `products` | `org_id` (FK), `name`, `description`, `sku`, `category` | → `ProductSupplier` (one-to-many) |
+| `ProductSupplier` | `product_suppliers` | `product_id` (FK), `supplier_id` (FK), `is_active` | → `Supplier` / Unique on `(product_id, supplier_id)` |
+
+### Key design decisions
+
+- **UUIDs as primary keys** — Every model uses UUIDs instead of auto-incrementing integers. This prevents ID enumeration attacks and makes it safe to expose IDs in URLs.
+- **Org-scoping via foreign key** — Business data models (`Supplier`, `Product`) have an `org_id` foreign key. This is the foundation of multi-tenancy.
+- **Soft state on memberships** — `OrgMembership.is_active` allows deactivating members without deleting their data. They can be reactivated later.
+- **Join table with metadata** — `ProductSupplier` is not just a simple many-to-many join. It has an `is_active` flag, allowing you to deactivate a specific product-supplier relationship without removing it.
+
+---
+
+## Database Migrations (Alembic)
+
+[Alembic](https://alembic.sqlalchemy.org/) manages database schema changes. Migration files live in `alembic/versions/`.
+
+### Running migrations
+
+```bash
+# Via Docker (recommended)
+docker compose exec api alembic upgrade head
+
+# Via Makefile (local, with venv activated)
+make migrate
+
+# Windows (manual)
+python -m alembic upgrade head
+```
+
+### Generating a new migration
+
+After changing a model (adding a column, a new table, changing a constraint, etc.):
+
+```bash
+# Via Docker
+docker compose exec api alembic revision --autogenerate -m "add category to products"
+
+# Via Makefile (local)
+make migrate-generate msg="add category to products"
+
+# Windows
+python -m alembic revision --autogenerate -m "add category to products"
+```
+
+**Always review the generated migration** before applying it. Alembic's autogenerate is good but not perfect — it may miss:
+- Data migrations (populating new columns with default values)
+- Index changes
+- Enum value additions
+- Complex constraint modifications
+
+### Rolling back
+
+```bash
+# Rollback the last migration
+docker compose exec api alembic downgrade -1
+
+# Or via Makefile
+make migrate-down
+
+# Windows
+python -m alembic downgrade -1
+```
+
+### Viewing history
+
+```bash
+docker compose exec api alembic history
+```
+
+### Connecting to the database directly
+
+```bash
+# Via Docker Compose
+docker compose exec db psql -U postgres -d easyinventory
+
+# Via Makefile
+make db-shell
+```
+
+> **Important:** If you run Alembic locally (outside Docker), make sure `DATABASE_URL` points to `localhost`, not `db`. The `db` hostname only resolves inside the Docker network.
+
+---
+
+## Domain Exception System
+
+The service layer and permission helpers raise **domain exceptions** instead of HTTP exceptions. A custom exception handler in `app/main.py` automatically converts them to JSON HTTP responses with the appropriate status code.
+
+### Why?
+
+- **Separation of concerns:** Services don't know about HTTP. They express business errors in business terms.
+- **Testability:** You can test services without FastAPI — just catch the domain exceptions.
+- **Consistency:** All error responses have the same shape: `{"detail": "error message"}`.
+
+### Exception hierarchy
+
+All exceptions inherit from `AppError` and are defined in `app/core/exceptions.py`:
+
+```
+AppError (400)                         # Base — catch-all for domain errors
+├── NotAuthenticated (401)             # Missing or invalid credentials
+├── InsufficientPermission (403)       # User lacks required role
+│   ├── OwnerProtected (403)           # "Cannot {action} the organization owner"
+│   └── AdminHierarchyViolation (403)  # "Only the owner can {action} an admin"
+├── NotFound (404)                     # Resource does not exist
+├── AlreadyExists (400)               # Duplicate resource
+└── InvalidRole (400)                  # Invalid role value
+```
+
+### Usage in services
+
+```python
+from app.core.exceptions import NotFound, AlreadyExists
+
+async def get_supplier(db: AsyncSession, supplier_id: UUID, org_id: UUID):
+    supplier = await db.get(Supplier, supplier_id)
+    if not supplier or supplier.org_id != org_id:
+        raise NotFound("Supplier not found")
+    return supplier
+
+async def create_supplier(db: AsyncSession, org_id: UUID, name: str):
+    if await supplier_name_exists(db, name, org_id):
+        raise AlreadyExists("A supplier with that name already exists")
+    # ... create the supplier
+```
+
+### What the client sees
+
+```json
+HTTP 404
+{"detail": "Supplier not found"}
+```
+
+> **Rule:** Never raise `HTTPException` in the service layer. Always use domain exceptions from `app/core/exceptions.py`. The exception handler takes care of the HTTP mapping.
+
+---
+
+## Bootstrap & Seed Data
+
+On every application startup, the **bootstrap seeder** (`app/bootstrap/seeder.py`) runs. It is fully **idempotent** — safe to run multiple times without creating duplicates.
+
+### What it does
+
+If `BOOTSTRAP_ADMIN_EMAIL` is configured in `.env`:
+
+1. **Creates a user** with that email (as a placeholder if they haven't signed up via Cognito yet).
+2. **Creates an organization** named per `BOOTSTRAP_ORG_NAME` (defaults to "Default Organization").
+3. **Makes the user the `ORG_OWNER`** of that organization.
+4. **Promotes the user to `SYSTEM_ADMIN`** system role.
+5. **Seeds sample data** — suppliers, products, and product-supplier links (defined in `app/bootstrap/seed_data.py`).
+
+### Sample seed data
+
+| Type | Items |
+|---|---|
+| **Suppliers** | Fresh Farms Produce, Pacific Coast Seafood, Valley Grains Co., Mountain Spring Water |
+| **Products** | Organic Apples, Whole Wheat Flour, Organic Oranges, Whole Milk, Brown Rice |
+| **Links** | Various product-supplier connections |
+
+### Becoming a System Admin
+
+There are currently two ways to become a `SYSTEM_ADMIN`:
+
+**1. Bootstrap (automatic):** Set `BOOTSTRAP_ADMIN_EMAIL` in `.env` to your email. On next startup, you'll be promoted.
+
+**2. Manual database update:**
+
+```bash
+# Via Docker
+docker compose exec db psql -U postgres -d easyinventory \
+  -c "UPDATE users SET system_role = 'SYSTEM_ADMIN' WHERE email = 'admin@company.com';"
+```
+
+```powershell
+# Windows (PowerShell) — all one line
+docker compose exec db psql -U postgres -d easyinventory -c "UPDATE users SET system_role = 'SYSTEM_ADMIN' WHERE email = 'admin@company.com';"
+```
+
+---
+
+## Related Guides
+
+- [Getting Started](getting-started.md) — Installation and setup
+- [API Reference](api-reference.md) — All endpoints and their parameters
+- [Developer Guide](developer-guide.md) — Coding standards, testing, adding features
+- [Deployment Guide](deployment-guide.md) — Production deployment
+- [Troubleshooting](troubleshooting.md) — Common issues and fixes

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -111,7 +111,7 @@ Create a `.env.prod` file on your server with the following variables:
 | `AWS_REGION` | `us-east-1` | AWS region for ECR and CloudWatch |
 | `AWS_ACCOUNT_ID` | `123456789012` | Your AWS account ID |
 | `COGNITO_REGION` | `us-east-2` | Region of your Cognito User Pool |
-| `COGNITO_USER_POOL_ID` | `us-east-2_Fc70cHz7B` | Cognito User Pool ID |
+| `COGNITO_USER_POOL_ID` | `us-east-2_XXXXXXXXX` | Cognito User Pool ID |
 | `COGNITO_APP_CLIENT_ID` | `4bjjm8t2...` | Cognito App Client ID |
 | `CORS_ORIGINS` | `https://<your-domain>` | Allowed CORS origins (comma-separated) |
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -1,0 +1,477 @@
+# Deployment Guide
+
+How to deploy the EasyInventory API to production using Docker, AWS ECR, and Caddy for automatic HTTPS.
+
+---
+
+## Table of Contents
+
+- [Architecture Overview](#architecture-overview)
+- [Docker Images](#docker-images)
+- [Production Environment Variables](#production-environment-variables)
+- [Build & Push to ECR](#build--push-to-ecr)
+- [Server Setup](#server-setup)
+- [Deploy Script](#deploy-script)
+- [Caddy Configuration](#caddy-configuration)
+- [Database in Production](#database-in-production)
+- [Logging (CloudWatch)](#logging-cloudwatch)
+- [Manual Operations](#manual-operations)
+- [Rollback](#rollback)
+
+---
+
+## Architecture Overview
+
+The production setup runs **four Docker containers** behind Caddy for automatic HTTPS:
+
+```
+              Internet
+                 │
+        ┌────────▼────────┐
+        │     Caddy        │  ← Automatic HTTPS (Let's Encrypt)
+        │     :80 / :443   │
+        └─┬────────────┬──┘
+          │            │
+   <your-domain>  api.<your-domain>
+          │            │
+    ┌─────▼─────┐  ┌──▼──────────────────────┐
+    │   Web     │  │   API                    │
+    │   :3000   │  │   :8000                  │
+    │ (frontend)│  │   Gunicorn + Uvicorn     │
+    └───────────┘  │   2 async workers        │
+                   └──────────┬───────────────┘
+                              │
+                    ┌─────────▼──────────┐
+                    │   PostgreSQL 16    │
+                    │   :5432 (local)    │
+                    └────────────────────┘
+```
+
+| Service | Image | Description |
+|---|---|---|
+| **db** | `postgres:16-alpine` | PostgreSQL database with persistent volume |
+| **api** | `<aws-account-id>.dkr.ecr.<region>.amazonaws.com/easyinventory/api:latest` | FastAPI + Gunicorn (2 workers) |
+| **web** | `<aws-account-id>.dkr.ecr.<region>.amazonaws.com/easyinventory/web:latest` | Frontend application |
+| **caddy** | `caddy:2-alpine` | Reverse proxy with auto-HTTPS |
+
+---
+
+## Docker Images
+
+The project has **two Dockerfiles** — one for development, one for production:
+
+| File | Python | Server | Use Case |
+|---|---|---|---|
+| `Dockerfile` | 3.11-slim | Uvicorn (single process) | Local development |
+| `Dockerfile.api` | 3.12-slim | Gunicorn + Uvicorn workers | Production |
+
+### Production Dockerfile details
+
+```dockerfile
+# Dockerfile.api — production image
+FROM python:3.12-slim
+WORKDIR /app
+
+# asyncpg needs system libraries for Postgres
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc libpq-dev && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt gunicorn uvicorn
+COPY . .
+
+EXPOSE 8000
+CMD ["gunicorn", "app.main:app", \
+     "-w", "2", \
+     "-k", "uvicorn.workers.UvicornWorker", \
+     "--bind", "0.0.0.0:8000", \
+     "--access-logfile", "-", \
+     "--error-logfile", "-"]
+```
+
+**Key differences from dev:**
+- Python 3.12 (latest stable) instead of 3.11
+- Installs `gcc` and `libpq-dev` for asyncpg compilation
+- Gunicorn with 2 Uvicorn workers (handles concurrent requests via multiple processes)
+- Access and error logs written to stdout (captured by Docker logging)
+
+---
+
+## Production Environment Variables
+
+Create a `.env.prod` file on your server with the following variables:
+
+### Required
+
+| Variable | Example | Description |
+|---|---|---|
+| `DB_USER` | `postgres` | PostgreSQL username |
+| `DB_PASSWORD` | `<strong-password>` | PostgreSQL password |
+| `DB_NAME` | `easyinventory` | Database name |
+| `AWS_REGION` | `us-east-1` | AWS region for ECR and CloudWatch |
+| `AWS_ACCOUNT_ID` | `123456789012` | Your AWS account ID |
+| `COGNITO_REGION` | `us-east-2` | Region of your Cognito User Pool |
+| `COGNITO_USER_POOL_ID` | `us-east-2_Fc70cHz7B` | Cognito User Pool ID |
+| `COGNITO_APP_CLIENT_ID` | `4bjjm8t2...` | Cognito App Client ID |
+| `CORS_ORIGINS` | `https://<your-domain>` | Allowed CORS origins (comma-separated) |
+
+### Optional
+
+| Variable | Default | Description |
+|---|---|---|
+| `BOOTSTRAP_ADMIN_EMAIL` | — | Email to auto-promote as SYSTEM_ADMIN on boot |
+| `BOOTSTRAP_ORG_NAME` | `"Default Organization"` | Name of the auto-created org |
+| `DEBUG` | `false` | Enable SQL query logging (never true in prod) |
+
+### Example `.env.prod`
+
+```bash
+DB_USER=postgres
+DB_PASSWORD=your-strong-password-here
+DB_NAME=easyinventory
+AWS_REGION=us-east-1
+AWS_ACCOUNT_ID=123456789012
+COGNITO_REGION=us-east-2
+COGNITO_USER_POOL_ID=us-east-2_XXXXXXXXX
+COGNITO_APP_CLIENT_ID=your-client-id
+CORS_ORIGINS=https://<your-domain>
+BOOTSTRAP_ADMIN_EMAIL=admin@example.com
+```
+
+> **Security:** Never commit `.env.prod` to git. Add it to `.gitignore`.
+
+---
+
+## Build & Push to ECR
+
+The `build-and-push.sh` script builds Docker images for both the API and the frontend, then pushes them to AWS ECR.
+
+### Prerequisites
+
+1. **AWS CLI** installed and configured with permissions for ECR.
+2. **Docker** installed and running.
+3. **ECR repositories created:**
+   - `easyinventory/api`
+   - `easyinventory/web`
+4. **`AWS_ACCOUNT_ID` environment variable set.**
+
+### Creating ECR repositories (first time only)
+
+```bash
+aws ecr create-repository --repository-name easyinventory/api --region us-east-1
+aws ecr create-repository --repository-name easyinventory/web --region us-east-1
+```
+
+### Running the build
+
+```bash
+export AWS_ACCOUNT_ID=123456789012
+./build-and-push.sh
+```
+
+**What the script does:**
+
+1. Logs into ECR using `aws ecr get-login-password`.
+2. Builds the API image from `Dockerfile.api` (targeting `linux/amd64`).
+3. Tags and pushes the API image to ECR.
+4. Builds the frontend image from the sibling `easyinventory-web/` directory.
+5. Tags and pushes the web image to ECR.
+
+> **Important:** The script builds for `linux/amd64`. If your dev machine is Apple Silicon (ARM), Docker will cross-compile. This is slower but produces images compatible with most cloud servers.
+
+---
+
+## Server Setup
+
+### Initial setup (first deployment)
+
+1. **Provision a server** (EC2, DigitalOcean, etc.) running Ubuntu or Amazon Linux.
+
+2. **Install Docker and Docker Compose:**
+
+   ```bash
+   # Ubuntu
+   sudo apt-get update
+   sudo apt-get install -y docker.io docker-compose-plugin
+   sudo usermod -aG docker $USER
+   # Log out and back in for group change to take effect
+   ```
+
+3. **Install AWS CLI:**
+
+   ```bash
+   curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+   unzip awscliv2.zip
+   sudo ./aws/install
+   aws configure  # Enter your credentials
+   ```
+
+4. **Clone the repo** (or just copy the necessary files):
+
+   ```bash
+   git clone <your-repo-url>
+   cd easyinventory-api
+   ```
+
+5. **Create `.env.prod`** with your production values (see above).
+
+6. **Update the Caddyfile** with your actual domain:
+
+   ```
+   <your-domain> {
+       reverse_proxy web:3000
+   }
+
+   api.<your-domain> {
+       reverse_proxy api:8000
+   }
+   ```
+
+7. **Point your DNS** — Create A records for `<your-domain>` and `api.<your-domain>` pointing to your server's IP.
+
+8. **Run the first deployment:**
+
+   ```bash
+   # Login to ECR
+   aws ecr get-login-password --region us-east-1 | \
+     docker login --username AWS --password-stdin \
+     <aws-account-id>.dkr.ecr.us-east-1.amazonaws.com
+
+   # Pull images and start all services
+   docker compose --env-file .env.prod -f docker-compose.prod.yml pull
+   docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
+
+   # Run database migrations
+   docker compose --env-file .env.prod -f docker-compose.prod.yml exec api alembic upgrade head
+   ```
+
+9. **Verify:** Open `https://<your-domain>` — Caddy will automatically obtain a TLS certificate.
+
+---
+
+## Deploy Script
+
+For subsequent deployments after the initial setup, use the `deploy.sh` script:
+
+```bash
+./deploy.sh
+```
+
+**What the script does:**
+
+1. Sources `.env.prod` for AWS credentials.
+2. Logs into ECR.
+3. Pulls the latest `api` image.
+4. Restarts the `api` container with `docker compose up -d api`.
+5. Runs `alembic upgrade head` to apply any pending database migrations.
+6. Prunes dangling Docker images to free disk space.
+
+### Full deployment workflow
+
+```bash
+# On your dev machine: build and push new images
+export AWS_ACCOUNT_ID=123456789012
+./build-and-push.sh
+
+# On the server: pull and deploy
+ssh your-server
+cd easyinventory-api
+./deploy.sh
+```
+
+---
+
+## Caddy Configuration
+
+The `Caddyfile` configures Caddy as a reverse proxy with automatic HTTPS:
+
+```
+<your-domain> {
+    reverse_proxy web:3000
+}
+
+api.<your-domain> {
+    reverse_proxy api:8000
+}
+```
+
+### How it works
+
+- Caddy automatically obtains and renews TLS certificates from Let's Encrypt.
+- HTTP (port 80) is automatically redirected to HTTPS (port 443).
+- The `web` and `api` hostnames resolve to their Docker containers via Docker's internal DNS.
+
+### Caddy volumes
+
+The production `docker-compose.prod.yml` mounts two volumes for Caddy:
+
+| Volume | Purpose |
+|---|---|
+| `caddy_data` | Stores TLS certificates and ACME data |
+| `caddy_config` | Stores auto-generated Caddy config |
+
+> **Important:** Don't delete these volumes — if you do, Caddy will need to re-obtain certificates from Let's Encrypt (which has rate limits).
+
+---
+
+## Database in Production
+
+### Persistent storage
+
+PostgreSQL data is stored in a Docker volume (`pgdata`). This persists across container restarts.
+
+### Running migrations
+
+Migrations run automatically as part of `deploy.sh`. To run them manually:
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml exec api alembic upgrade head
+```
+
+### Database backups
+
+The production setup does not include automated backups. You should set up periodic backups:
+
+```bash
+# Manual backup
+docker compose --env-file .env.prod -f docker-compose.prod.yml exec db \
+  pg_dump -U postgres easyinventory > backup_$(date +%Y%m%d).sql
+
+# Restore from backup
+docker compose --env-file .env.prod -f docker-compose.prod.yml exec -T db \
+  psql -U postgres easyinventory < backup_20240115.sql
+```
+
+Consider using a cron job or AWS RDS for automated backups in production.
+
+### Connecting to the database
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml exec db \
+  psql -U postgres -d easyinventory
+```
+
+> **Note:** The database port (`5432`) is bound to `127.0.0.1` in production — it is not accessible from outside the server.
+
+---
+
+## Logging (CloudWatch)
+
+All four services use the `awslogs` Docker logging driver to send logs to **AWS CloudWatch**:
+
+| Service | Log Group | Log Stream |
+|---|---|---|
+| db | `/easyinventory/db` | `db` |
+| api | `/easyinventory/api` | `api` |
+| web | `/easyinventory/web` | `web` |
+| caddy | `/easyinventory/caddy` | `caddy` |
+
+### Prerequisites
+
+- The EC2 instance (or server) must have an **IAM role** with `CloudWatchLogsFullAccess` permissions, or you must configure the AWS credentials on the server.
+- Log groups are created automatically (`awslogs-create-group: "true"`).
+
+### Viewing logs
+
+```bash
+# Via AWS CLI
+aws logs tail /easyinventory/api --follow
+
+# Or view in the AWS Console:
+# CloudWatch → Log groups → /easyinventory/api
+```
+
+### Local Docker logs (fallback)
+
+If CloudWatch is not configured, you can still view logs locally:
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml logs -f api
+docker compose --env-file .env.prod -f docker-compose.prod.yml logs -f db
+```
+
+---
+
+## Manual Operations
+
+### Restart a single service
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml restart api
+```
+
+### Restart all services
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml down
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
+```
+
+### View running containers
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml ps
+```
+
+### Shell into the API container
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml exec api /bin/bash
+```
+
+### Promote a System Admin
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml exec db \
+  psql -U postgres -d easyinventory \
+  -c "UPDATE users SET system_role = 'SYSTEM_ADMIN' WHERE email = 'admin@example.com';"
+```
+
+---
+
+## Rollback
+
+If a deployment breaks something, you can rollback to the previous image:
+
+### Quick rollback (restart with cached image)
+
+If the old image is still cached on the server:
+
+```bash
+# List available local images
+docker images | grep easyinventory
+
+# Tag the previous image as latest
+docker tag <previous-image-id> \
+  <aws-account-id>.dkr.ecr.<region>.amazonaws.com/easyinventory/api:latest
+
+# Restart the container
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d api
+```
+
+### Rollback via ECR
+
+If you need to pull an older image:
+
+1. Check available tags in ECR (AWS Console or CLI).
+2. Update `docker-compose.prod.yml` to use a specific tag instead of `latest`.
+3. Pull and restart.
+
+### Database migration rollback
+
+If a migration caused issues:
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml exec api alembic downgrade -1
+```
+
+> **Tip:** Always take a database backup before deploying migrations that modify existing data.
+
+---
+
+## Related Guides
+
+- [Getting Started](getting-started.md) — Local development setup
+- [Architecture](architecture.md) — System design and components
+- [Developer Guide](developer-guide.md) — Contributing and testing
+- [Troubleshooting](troubleshooting.md) — Common issues and fixes

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,0 +1,602 @@
+# Developer Guide
+
+Everything you need to contribute to the EasyInventory API: coding standards, testing, how to add a new feature end-to-end, and the Makefile command reference.
+
+---
+
+## Table of Contents
+
+- [Development Workflow](#development-workflow)
+- [Code Formatting & Linting](#code-formatting--linting)
+- [Type Checking (mypy)](#type-checking-mypy)
+- [Testing](#testing)
+  - [Test Suite 1: Mocked Database (tests/)](#test-suite-1-mocked-database-tests)
+  - [Test Suite 2: Real Database (testsv2/)](#test-suite-2-real-database-testsv2)
+  - [Writing New Tests](#writing-new-tests)
+- [Adding a New Feature (End-to-End Walkthrough)](#adding-a-new-feature-end-to-end-walkthrough)
+- [Key Patterns & Conventions](#key-patterns--conventions)
+- [Git Workflow](#git-workflow)
+- [Makefile Reference](#makefile-reference)
+
+---
+
+## Development Workflow
+
+1. **Pull the latest `main`** — `git pull origin main`
+2. **Create a feature branch** — `git checkout -b feature/my-feature`
+3. **Make your changes** — follow the patterns below
+4. **Run formatting** — `make format`
+5. **Run type checking** — `make typecheck`
+6. **Run tests** — `make test` (mocked) and/or `make test-v2` (real DB)
+7. **Commit** — use conventional commit messages
+8. **Push and create a PR**
+
+---
+
+## Code Formatting & Linting
+
+The project uses [Black](https://github.com/psf/black) for code formatting.
+
+**Configuration** (in `pyproject.toml`):
+
+```toml
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+```
+
+### Commands
+
+```bash
+# Check formatting (does not modify files)
+make format-check
+
+# Auto-fix formatting
+make format
+
+# These are equivalent
+make format-fix
+```
+
+```powershell
+# Windows (PowerShell)
+python -m black --check app/ tests/ testsv2/    # check
+python -m black app/ tests/ testsv2/            # fix
+```
+
+### Rules
+
+- **Line length:** 88 characters max.
+- **All Python files** in `app/`, `tests/`, and `testsv2/` are formatted.
+- **Run `make format` before committing.** CI will reject unformatted code.
+
+---
+
+## Type Checking (mypy)
+
+The project uses [mypy](https://mypy-lang.org/) for static type checking.
+
+**Configuration** (in `mypy.ini`):
+
+```ini
+[mypy]
+python_version = 3.11
+warn_return_any = True
+warn_unused_configs = True
+disallow_untyped_defs = True        # All functions MUST have type annotations
+ignore_missing_imports = True
+
+[mypy-tests.*]
+disallow_untyped_defs = False       # Tests are exempt from type annotations
+```
+
+### Commands
+
+```bash
+make typecheck
+
+# Or directly
+python -m mypy app/
+```
+
+```powershell
+# Windows
+python -m mypy app/
+```
+
+### Rules
+
+- **All functions in `app/` must have type annotations** — both parameters and return types.
+- **Tests are exempt** — the `[mypy-tests.*]` section relaxes the requirement.
+- **Third-party imports are ignored** — `ignore_missing_imports = True` prevents errors from untyped packages.
+
+---
+
+## Testing
+
+The project has **two independent test suites** with different trade-offs:
+
+| Suite | Location | Database | Speed | Fidelity |
+|---|---|---|---|---|
+| **Suite 1** | `tests/` | Mocked (no Postgres needed) | Fast | Tests logic in isolation |
+| **Suite 2** | `testsv2/` | Real Postgres (transaction rollback) | Slower | Tests real SQL behavior |
+
+Both suites use `pytest` with `asyncio_mode = "auto"` (async tests run without extra decorators).
+
+---
+
+### Test Suite 1: Mocked Database (`tests/`)
+
+Uses `httpx.AsyncClient` with `ASGITransport` to call the app directly — no network, no database. All dependencies (database sessions, auth) are mocked or patched.
+
+**Run all Suite 1 tests:**
+
+```bash
+make test
+```
+
+**Run only unit tests:**
+
+```bash
+make test-unit
+```
+
+**Run only functional tests:**
+
+```bash
+make test-functional
+```
+
+```powershell
+# Windows
+python -m pytest tests/ -v
+python -m pytest tests/unit/ -v
+python -m pytest tests/functional/ -v
+```
+
+**How it works:**
+
+```python
+# tests/conftest.py
+@pytest.fixture
+def app():
+    return create_app()
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+```
+
+**When to use:** For fast feedback during development, logic that doesn't depend on real SQL queries, testing route authorization, testing error handling.
+
+---
+
+### Test Suite 2: Real Database (`testsv2/`)
+
+Runs against a **real PostgreSQL instance** with transaction-per-test rollback for isolation. Each test gets a real database session wrapped in a transaction that is always rolled back — so every test starts with a clean database.
+
+**Step 1:** Start the test database (separate from the dev database):
+
+```bash
+make test-db
+```
+
+This starts a Docker container named `easyinventory-test-db` on port **5433** (not 5432, so it doesn't conflict with dev).
+
+**Step 2:** Run Suite 2 tests:
+
+```bash
+make test-v2
+```
+
+This automatically runs `alembic upgrade head` on the test database before running tests.
+
+**Step 3:** Stop the test database when done:
+
+```bash
+make test-db-stop
+```
+
+```powershell
+# Windows — manual equivalent of make test-db
+docker run -d --name easyinventory-test-db `
+  -e POSTGRES_USER=test `
+  -e POSTGRES_PASSWORD=test `
+  -e POSTGRES_DB=easyinventory_test `
+  -p 5433:5432 `
+  postgres:16-alpine
+
+# Wait for Postgres to be ready, then:
+$env:DATABASE_URL = "postgresql+asyncpg://test:test@localhost:5433/easyinventory_test"
+python -m alembic upgrade head
+python -m pytest testsv2/ -v
+```
+
+**How it works:**
+
+The `testsv2/conftest.py` creates a session fixture using the **nested transaction pattern**:
+
+1. An **outer transaction** is opened on a raw connection.
+2. A **session** is created, bound to that connection.
+3. A **nested transaction** (SAVEPOINT) is started.
+4. When application code calls `session.commit()`, it only releases the savepoint (not the outer transaction).
+5. After the test, the outer transaction is **rolled back** — nothing is written to the database.
+
+This gives each test a completely clean database without needing to truncate tables.
+
+**When to use:** For testing real SQL queries, Alembic migrations, complex joins, race conditions, anything where mocking the database would hide bugs.
+
+---
+
+### Writing New Tests
+
+#### Suite 1 test example (mocked)
+
+```python
+# tests/unit/test_my_feature.py
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.myfeature.service import get_thing
+
+
+@pytest.mark.asyncio
+async def test_get_thing_not_found():
+    db = AsyncMock()
+    db.execute.return_value.scalar_one_or_none.return_value = None
+
+    with pytest.raises(NotFound, match="Thing not found"):
+        await get_thing(db, thing_id=uuid4(), org_id=uuid4())
+```
+
+#### Suite 2 test example (real database)
+
+```python
+# testsv2/integration/test_my_feature.py
+import pytest
+from testsv2.factories import create_org_with_owner, create_supplier
+
+
+@pytest.mark.asyncio
+async def test_create_supplier(db):
+    org, owner, _ = await create_org_with_owner(db)
+
+    supplier = await create_supplier(
+        db,
+        org_id=org.id,
+        name="Test Supplier",
+    )
+
+    assert supplier.id is not None
+    assert supplier.name == "Test Supplier"
+    assert supplier.org_id == org.id
+```
+
+#### Using factories (`testsv2/`)
+
+The `testsv2/factories.py` module provides helper functions that INSERT real rows:
+
+| Factory | What It Creates |
+|---|---|
+| `create_user(db, ...)` | A `User` row with defaults |
+| `create_org(db, ...)` | An `Organization` row |
+| `create_membership(db, ...)` | An `OrgMembership` row |
+| `create_org_with_owner(db, ...)` | An org + user + OWNER membership (returns tuple) |
+| `create_supplier(db, ...)` | A `Supplier` row |
+| `create_product(db, ...)` | A `Product` row |
+| `create_product_supplier(db, ...)` | A `ProductSupplier` link |
+
+All factories accept keyword arguments to override defaults.
+
+---
+
+## Adding a New Feature (End-to-End Walkthrough)
+
+Let's walk through adding a **Categories** feature — a new domain that manages product categories within an organization.
+
+### Step 1: Create the model
+
+```python
+# app/models/category.py
+from sqlalchemy import Column, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models.base import BaseModel
+
+
+class Category(BaseModel):
+    __tablename__ = "categories"
+
+    org_id = Column(UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+```
+
+### Step 2: Register the model
+
+```python
+# app/models/__init__.py — add the import
+from app.models.category import Category  # noqa: F401
+```
+
+### Step 3: Generate a migration
+
+```bash
+make migrate-generate msg="add categories table"
+```
+
+Review the generated file in `alembic/versions/`, then apply:
+
+```bash
+make migrate
+# or: docker compose exec api alembic upgrade head
+```
+
+### Step 4: Create schemas
+
+```python
+# app/categories/schemas.py
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class CategoryCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+
+
+class CategoryUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+
+class CategoryResponse(BaseModel):
+    id: uuid.UUID
+    org_id: uuid.UUID
+    name: str
+    description: Optional[str]
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+```
+
+### Step 5: Create the service
+
+```python
+# app/categories/service.py
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import NotFound
+from app.models.category import Category
+
+
+async def list_categories(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+) -> list[Category]:
+    result = await db.execute(
+        select(Category).where(Category.org_id == org_id)
+    )
+    return list(result.scalars().all())
+
+
+async def get_category(
+    db: AsyncSession,
+    category_id: uuid.UUID,
+    org_id: uuid.UUID,
+) -> Category | None:
+    result = await db.execute(
+        select(Category).where(
+            Category.id == category_id,
+            Category.org_id == org_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def create_category(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    name: str,
+    description: str | None = None,
+) -> Category:
+    category = Category(org_id=org_id, name=name, description=description)
+    db.add(category)
+    await db.flush()
+    await db.refresh(category)
+    return category
+```
+
+### Step 6: Create the routes
+
+```python
+# app/categories/routes.py
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.orgs.deps import get_current_org_membership
+from app.core.database import get_db
+from app.models.org_membership import OrgMembership
+from app.categories.schemas import CategoryCreate, CategoryResponse
+from app.categories import service as category_service
+
+router = APIRouter(prefix="/api/categories", tags=["categories"])
+
+
+@router.get("", response_model=list[CategoryResponse])
+async def list_categories(
+    membership: OrgMembership = Depends(get_current_org_membership),
+    db: AsyncSession = Depends(get_db),
+) -> list:
+    return await category_service.list_categories(db, membership.org_id)
+
+
+@router.post("", response_model=CategoryResponse, status_code=201)
+async def create_category(
+    body: CategoryCreate,
+    membership: OrgMembership = Depends(get_current_org_membership),
+    db: AsyncSession = Depends(get_db),
+) -> CategoryResponse:
+    category = await category_service.create_category(
+        db=db,
+        org_id=membership.org_id,
+        name=body.name,
+        description=body.description,
+    )
+    return CategoryResponse.model_validate(category)
+```
+
+### Step 7: Register the routes
+
+```python
+# app/main.py — in create_app(), add:
+from app.categories.routes import router as categories_router
+app.include_router(categories_router)
+```
+
+### Step 8: Don't forget
+
+- [ ] Create `app/categories/__init__.py` (empty file)
+- [ ] Add tests (both suites)
+- [ ] Add a factory to `testsv2/factories.py`
+- [ ] Run `make format && make typecheck && make test`
+
+---
+
+## Key Patterns & Conventions
+
+### 1. Domain module structure
+
+Every domain follows the same 3-file pattern. See [Architecture: Domain Module Pattern](architecture.md#domain-module-pattern).
+
+### 2. Service functions are pure database operations
+
+Services accept `db: AsyncSession` and other arguments. They return ORM model instances. They **never** raise `HTTPException` — they raise domain exceptions from `app/core/exceptions.py`.
+
+### 3. Org-scoping
+
+Every business query **must** filter by `org_id`. Never return data across organizations. The `org_id` comes from the authenticated membership, **never** from the request body.
+
+### 4. UUID primary keys
+
+All models use UUIDs. Use `uuid.uuid4()` for test data. Never use sequential integers.
+
+### 5. Pydantic v2 conventions
+
+```python
+class MyResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    model_config = {"from_attributes": True}  # Required for ORM → schema conversion
+```
+
+### 6. Async everywhere
+
+All database operations are async. Use `await` for every SQLAlchemy call:
+
+```python
+result = await db.execute(select(Model).where(...))
+items = list(result.scalars().all())
+```
+
+### 7. Import style
+
+```python
+# Absolute imports only
+from app.core.database import get_db       # ✓
+from ..core.database import get_db         # ✗ Never use relative imports
+```
+
+### 8. Dependencies via injection
+
+Auth, org membership, and database sessions are injected via FastAPI `Depends()`. Never create sessions manually in routes.
+
+---
+
+## Git Workflow
+
+### Branch naming
+
+```
+feature/add-categories
+fix/supplier-delete-cascade
+chore/update-dependencies
+refactor/auth-middleware
+```
+
+### Commit messages
+
+Use conventional commit format:
+
+```
+feat: add categories CRUD endpoints
+fix: prevent duplicate product-supplier links
+test: add integration tests for supplier service
+refactor: extract invite logic into service module
+chore: update dev-requirements.txt
+docs: add deployment guide
+```
+
+### PR checklist
+
+Before creating a pull request:
+
+- [ ] `make format` — code is formatted
+- [ ] `make typecheck` — no type errors
+- [ ] `make test` — all Suite 1 tests pass
+- [ ] `make test-v2` — all Suite 2 tests pass (if you changed DB logic)
+- [ ] New migrations reviewed (if any)
+- [ ] New endpoints documented
+
+---
+
+## Makefile Reference
+
+All commands assume you have a virtualenv activated (or are using Docker).
+
+| Command | Description |
+|---|---|
+| `make run` | Start dev server via Docker Compose (`docker compose up`) |
+| `make build` | Start dev server with image rebuild (`docker compose up --build`) |
+| `make test` | Run Suite 1 tests (mocked DB) |
+| `make test-unit` | Run Suite 1 unit tests only |
+| `make test-functional` | Run Suite 1 functional tests only |
+| `make test-db` | Start a dedicated test Postgres container (port 5433) |
+| `make test-db-stop` | Stop and remove the test Postgres container |
+| `make test-v2` | Run Suite 2 tests (requires `make test-db` first) |
+| `make lint` | Run formatting check + type checking |
+| `make format` | Auto-format all Python files with Black |
+| `make format-check` | Check formatting without modifying files |
+| `make format-fix` | Same as `make format` |
+| `make typecheck` | Run mypy type checking on `app/` |
+| `make migrate` | Apply all pending Alembic migrations |
+| `make migrate-generate msg="..."` | Auto-generate a new migration |
+| `make migrate-down` | Rollback the last migration |
+| `make db-shell` | Open a psql shell to the dev database |
+| `make clean` | Remove `__pycache__`, `.pytest_cache`, `.mypy_cache` |
+
+---
+
+## Related Guides
+
+- [Architecture](architecture.md) — System design, RBAC, exception system
+- [API Reference](api-reference.md) — All endpoints
+- [Getting Started](getting-started.md) — Setup and installation
+- [Deployment Guide](deployment-guide.md) — Production deployment
+- [Troubleshooting](troubleshooting.md) — Common issues and fixes

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -489,7 +489,7 @@ Every domain follows the same 3-file pattern. See [Architecture: Domain Module P
 
 ### 2. Service functions are pure database operations
 
-Services accept `db: AsyncSession` and other arguments. They return ORM model instances. They **never** raise `HTTPException` — they raise domain exceptions from `app/core/exceptions.py`.
+Services accept `db: AsyncSession` and other arguments. They return ORM model instances or domain-specific dataclasses (e.g. when the result involves aggregates that don't map 1:1 to a model). They **never** raise `HTTPException` — they raise domain exceptions from `app/core/exceptions.py`.
 
 ### 3. Org-scoping
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -22,14 +22,16 @@ Everything you need to contribute to the EasyInventory API: coding standards, te
 
 ## Development Workflow
 
-1. **Pull the latest `main`** — `git pull origin main`
+1. **Pull the latest `development`** — `git pull origin development`
 2. **Create a feature branch** — `git checkout -b feature/my-feature`
 3. **Make your changes** — follow the patterns below
 4. **Run formatting** — `make format`
 5. **Run type checking** — `make typecheck`
 6. **Run tests** — `make test` (mocked) and/or `make test-v2` (real DB)
 7. **Commit** — use conventional commit messages
-8. **Push and create a PR**
+8. **Push and create a PR** into `development`
+
+> **Branch strategy:** Feature branches are merged into `development`. When a release is ready, `development` is merged into `main`.
 
 ---
 
@@ -531,14 +533,17 @@ Auth, org membership, and database sessions are injected via FastAPI `Depends()`
 
 ## Git Workflow
 
-### Branch naming
+### Branching model
 
 ```
-feature/add-categories
-fix/supplier-delete-cascade
-chore/update-dependencies
-refactor/auth-middleware
+main           ← production releases only
+└── development  ← integration branch (merge feature branches here)
+    ├── feature/add-categories
+    ├── fix/supplier-delete-cascade
+    └── refactor/auth-middleware
 ```
+
+All feature branches are created from and merged back into `development`. When a release is ready, `development` is merged into `main`.
 
 ### Commit messages
 
@@ -555,7 +560,7 @@ docs: add deployment guide
 
 ### PR checklist
 
-Before creating a pull request:
+Before creating a pull request into `development`:
 
 - [ ] `make format` — code is formatted
 - [ ] `make typecheck` — no type errors

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,360 @@
+# Getting Started
+
+This guide walks you through setting up the EasyInventory API on your local machine. Choose between Docker (recommended — zero configuration) or running Python directly.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Quick Start — Docker (Recommended)](#quick-start--docker-recommended)
+- [Quick Start — Local Dev Without Docker](#quick-start--local-dev-without-docker)
+- [Environment Variables](#environment-variables)
+- [Next Steps](#next-steps)
+
+---
+
+## Prerequisites
+
+Before you begin, make sure you have the following tools installed on your machine.
+
+### Git
+
+Git is the version control system we use to manage our code.
+
+- **macOS:** Git comes pre-installed. Verify with `git --version`. If missing, install via [Homebrew](https://brew.sh/): `brew install git`
+- **Windows:** Download from [git-scm.com](https://git-scm.com/downloads). During installation, choose "Git from the command line and also from 3rd-party software."
+
+### Docker Desktop
+
+Docker lets you run the entire application (API + database) in isolated containers — no need to install PostgreSQL or Python manually.
+
+- **macOS:** Download from [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/)
+- **Windows:** Download from the same link. Requires WSL 2 (the installer will prompt you to enable it).
+
+After installing, **make sure Docker Desktop is running** (you should see the whale icon in your system tray / menu bar).
+
+### Python 3.11+ (for local dev without Docker)
+
+If you want to run the API directly on your machine (without Docker), you need Python 3.11 or newer.
+
+- **macOS:** `brew install python@3.11` or download from [python.org](https://www.python.org/downloads/)
+- **Windows:** Download from [python.org](https://www.python.org/downloads/). **Important:** Check the "Add Python to PATH" box during installation.
+
+Verify your installation:
+
+```bash
+# macOS / Linux
+python3 --version
+
+# Windows (Command Prompt or PowerShell)
+python --version
+```
+
+### AWS CLI (optional)
+
+Only needed if you are deploying to production or testing Cognito invite flows locally. Install from [aws.amazon.com/cli](https://aws.amazon.com/cli/).
+
+---
+
+## Quick Start — Docker (Recommended)
+
+This is the fastest way to get the API running. Docker handles Python, PostgreSQL, and all dependencies for you.
+
+### 1. Clone the repository
+
+```bash
+# Same on macOS, Linux, and Windows
+git clone https://github.com/your-org/easyinventory-api.git
+cd easyinventory-api
+```
+
+### 2. Create your environment file
+
+The `.env` file holds configuration values (database URL, Cognito settings, etc.). We provide a template:
+
+```bash
+# macOS / Linux
+cp .env.example .env
+
+# Windows (Command Prompt)
+copy .env.example .env
+
+# Windows (PowerShell)
+Copy-Item .env.example .env
+```
+
+Open `.env` in your editor and fill in any required values. For local development, the defaults work out of the box — the Docker Compose setup overrides `DATABASE_URL` automatically. See [Environment Variables](#environment-variables) below for details on each setting.
+
+### 3. Build and start all services
+
+```bash
+# Same on all platforms
+docker compose up --build
+```
+
+This starts two containers:
+
+| Container | What it is | Port |
+|-----------|-----------|------|
+| **api** | FastAPI application (Uvicorn) | `localhost:8000` |
+| **db** | PostgreSQL 16 | `localhost:5432` |
+
+The API code is mounted as a volume, so any file changes you make are reflected immediately without rebuilding.
+
+> **Tip:** Add `-d` to run in detached mode (background): `docker compose up --build -d`
+
+### 4. Run database migrations
+
+In a **separate terminal** (while the containers are running):
+
+```bash
+# Same on all platforms
+docker compose exec api alembic upgrade head
+```
+
+This creates all the database tables. You only need to do this once, or whenever new migrations are added by the team.
+
+### 5. Verify everything is working
+
+```bash
+# macOS / Linux
+curl http://localhost:8000/health
+
+# Windows (PowerShell)
+Invoke-WebRequest -Uri http://localhost:8000/health | Select-Object -ExpandProperty Content
+
+# Windows (Command Prompt)
+curl http://localhost:8000/health
+```
+
+Expected response:
+
+```json
+{"status": "healthy", "service": "easyinventory-api"}
+```
+
+### You're up and running!
+
+- **API:** http://localhost:8000
+- **Swagger Docs (interactive):** http://localhost:8000/docs — try out endpoints directly in the browser
+- **ReDoc (readable):** http://localhost:8000/redoc — clean, searchable API documentation
+
+### Stopping the application
+
+```bash
+# Stop all containers (preserves data)
+docker compose down
+
+# Stop and remove ALL data (database wiped clean)
+docker compose down -v
+```
+
+### Rebuilding after dependency changes
+
+If someone adds a new Python package to `requirements.txt`, rebuild:
+
+```bash
+docker compose up --build
+```
+
+---
+
+## Quick Start — Local Dev Without Docker
+
+Use this approach if you prefer running the Python API directly on your machine. You still need PostgreSQL — the easiest way is to run just the database in Docker.
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/your-org/easyinventory-api.git
+cd easyinventory-api
+```
+
+### 2. Create a Python virtual environment
+
+A virtual environment (venv) is an isolated Python installation for this project. It keeps your system Python clean and prevents package conflicts between different projects on your machine.
+
+```bash
+# macOS / Linux
+python3 -m venv venv
+
+# Windows
+python -m venv venv
+```
+
+### 3. Activate the virtual environment
+
+You need to activate the venv **every time you open a new terminal** before running any project commands.
+
+```bash
+# macOS / Linux
+source venv/bin/activate
+
+# Windows (PowerShell)
+.\venv\Scripts\Activate.ps1
+
+# Windows (Command Prompt)
+venv\Scripts\activate.bat
+```
+
+You will know it's active when you see `(venv)` at the start of your terminal prompt.
+
+### 4. Install dependencies
+
+```bash
+# Same on all platforms (with venv activated)
+pip install -r dev-requirements.txt
+```
+
+This installs all runtime dependencies **plus** dev tools (pytest, black, mypy, httpx). If you only need runtime deps, use `requirements.txt` instead — but for development you want the full set.
+
+### 5. Create your environment file
+
+```bash
+# macOS / Linux
+cp .env.example .env
+
+# Windows (Command Prompt)
+copy .env.example .env
+
+# Windows (PowerShell)
+Copy-Item .env.example .env
+```
+
+### 6. Update DATABASE_URL for localhost
+
+When running outside Docker, the database hostname is `localhost` instead of `db`. Open `.env` and change the `DATABASE_URL` line:
+
+```dotenv
+# Change this (Docker internal hostname):
+# DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/easyinventory
+
+# To this (localhost):
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/easyinventory
+```
+
+> **Why?** Inside Docker, services talk to each other using container names (`db`). Outside Docker, the database is accessed via `localhost`.
+
+### 7. Start PostgreSQL via Docker
+
+Even if you're running the API locally, the easiest way to get PostgreSQL is through Docker:
+
+```bash
+# macOS / Linux
+docker run -d --name easyinventory-db \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=easyinventory \
+  -p 5432:5432 \
+  postgres:16
+```
+
+```powershell
+# Windows (PowerShell) — all one line
+docker run -d --name easyinventory-db -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=easyinventory -p 5432:5432 postgres:16
+```
+
+To check it's running: `docker ps` — you should see a `postgres:16` container.
+
+### 8. Run database migrations
+
+```bash
+# macOS / Linux
+python3 -m alembic upgrade head
+
+# Windows
+python -m alembic upgrade head
+```
+
+### 9. Start the development server
+
+```bash
+# macOS / Linux
+python3 run.py
+
+# Windows
+python run.py
+```
+
+Or equivalently:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+The `--reload` flag makes the server restart automatically when you change code. You'll see output like:
+
+```
+INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
+INFO:     Started reloader process [12345] using WatchFiles
+```
+
+### 10. Verify everything is working
+
+```bash
+# macOS / Linux
+curl http://localhost:8000/health
+
+# Windows (PowerShell)
+Invoke-WebRequest -Uri http://localhost:8000/health | Select-Object -ExpandProperty Content
+```
+
+Expected: `{"status": "healthy", "service": "easyinventory-api"}`
+
+---
+
+## Environment Variables
+
+All configuration is loaded from a `.env` file using [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/). The settings class is defined in `app/core/config.py`.
+
+### Required Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `DATABASE_URL` | — | PostgreSQL async connection string. Format: `postgresql+asyncpg://user:password@host:port/dbname` |
+| `COGNITO_REGION` | — | AWS region where your Cognito User Pool lives (e.g., `us-east-1`) |
+| `COGNITO_USER_POOL_ID` | — | Cognito User Pool ID (e.g., `us-east-1_AbC123`) |
+| `COGNITO_APP_CLIENT_ID` | — | Cognito App Client ID |
+
+### Optional Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `APP_NAME` | `EZInventory API` | Application name shown in Swagger docs title |
+| `DEBUG` | `false` | When `true`, SQLAlchemy logs every SQL query to the console. **Never enable in production.** |
+| `AWS_ACCESS_KEY_ID` | — | IAM credentials for Cognito admin operations (sending invite emails, deleting users). Not needed if you are only testing with mocked auth. |
+| `AWS_SECRET_ACCESS_KEY` | — | Corresponding IAM secret key |
+| `BOOTSTRAP_ADMIN_EMAIL` | — | If set, creates a bootstrap admin user + default organization on every startup. See [Architecture Guide — Bootstrap & Seed Data](architecture.md#bootstrap--seed-data). |
+| `BOOTSTRAP_ORG_NAME` | `Default Organization` | Name for the bootstrap organization |
+| `CORS_ORIGINS` | `http://localhost:5173` | Comma-separated list of allowed CORS origins (e.g., `http://localhost:5173,https://your-app.com`) |
+
+### Docker vs Local — DATABASE_URL
+
+When using Docker Compose, the `DATABASE_URL` is automatically overridden in `docker-compose.yml`:
+
+```
+postgresql+asyncpg://postgres:postgres@db:5432/easyinventory
+```
+
+The hostname `db` resolves to the PostgreSQL container inside the Docker network. When running locally (outside Docker), use `localhost` instead:
+
+```
+postgresql+asyncpg://postgres:postgres@localhost:5432/easyinventory
+```
+
+### Cognito Setup
+
+For full Cognito User Pool configuration instructions, see [cognito-setup.md](cognito-setup.md).
+
+---
+
+## Next Steps
+
+Now that you have the API running:
+
+- **Understand the system:** Read the [Architecture Guide](architecture.md) to learn how the codebase is organized, how auth works, and how data flows through the system.
+- **Explore the API:** Check the [API Reference](api-reference.md) for all available endpoints and their parameters.
+- **Start developing:** Read the [Developer Guide](developer-guide.md) for coding standards, testing, and a full walkthrough of adding new features.
+- **Deploy to production:** See the [Deployment Guide](deployment-guide.md) when you're ready to ship.
+- **Fix issues:** Check [Troubleshooting](troubleshooting.md) if something isn't working.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,475 @@
+# Troubleshooting
+
+Solutions for common issues you may encounter when developing, testing, or deploying the EasyInventory API.
+
+---
+
+## Table of Contents
+
+- [Docker & Startup Issues](#docker--startup-issues)
+- [Database Issues](#database-issues)
+- [Authentication Issues](#authentication-issues)
+- [Testing Issues](#testing-issues)
+- [API Runtime Errors](#api-runtime-errors)
+- [Deployment Issues](#deployment-issues)
+- [Code Quality Issues](#code-quality-issues)
+
+---
+
+## Docker & Startup Issues
+
+### Container exits immediately / `db` container not ready
+
+**Symptom:** `docker compose up` starts but the API container restarts or fails to connect to the database.
+
+**Cause:** The API starts before PostgreSQL is ready to accept connections.
+
+**Fix:**
+
+```bash
+# Stop everything
+docker compose down
+
+# Start the database first and wait for it
+docker compose up db -d
+sleep 5
+
+# Then start the API
+docker compose up api
+```
+
+Or simply re-run `docker compose up` — Docker will restart the API automatically once the database is ready (`restart: always` in production).
+
+---
+
+### Port 5432 already in use
+
+**Symptom:** `Error: bind: address already in use` when starting Docker Compose.
+
+**Cause:** Another PostgreSQL instance (or another Docker container) is using port 5432.
+
+**Fix:**
+
+```bash
+# Find what's using the port
+# macOS / Linux
+lsof -i :5432
+
+# Stop it, or change the port in docker-compose.yml:
+# ports:
+#   - "5433:5432"
+
+# Then update DATABASE_URL to use port 5433:
+# DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5433/easyinventory
+```
+
+```powershell
+# Windows
+netstat -aon | findstr :5432
+# Kill the process or change the port as described above
+```
+
+---
+
+### Port 8000 already in use
+
+**Symptom:** API won't start, port conflict error.
+
+**Fix:**
+
+```bash
+# macOS / Linux: find and kill the process
+lsof -i :8000
+kill <PID>
+
+# Or change the API port in docker-compose.yml
+```
+
+---
+
+### Docker Compose mounts not reflecting code changes
+
+**Symptom:** You edit a file but the running API doesn't pick up the change.
+
+**Cause:** Volume mounts only work in the dev `docker-compose.yml`. The production compose file uses baked-in images.
+
+**Fix (dev):** The dev `docker-compose.yml` mounts `.:/app`, so changes should reflect immediately with Uvicorn's `--reload`. If not:
+
+```bash
+docker compose restart api
+```
+
+---
+
+## Database Issues
+
+### `alembic upgrade head` fails with "relation already exists"
+
+**Symptom:** Migration error saying a table or column already exists.
+
+**Cause:** The database state is out of sync with the Alembic migration history — typically from manually creating tables or running `Base.metadata.create_all`.
+
+**Fix:**
+
+```bash
+# Check the current migration state
+docker compose exec api alembic current
+
+# If empty or wrong, stamp the database to the current head
+docker compose exec api alembic stamp head
+
+# If a specific migration is the problem, stamp to that revision
+docker compose exec api alembic stamp <revision_id>
+```
+
+---
+
+### "Connection refused" when running Alembic locally
+
+**Symptom:** `alembic upgrade head` fails with `Connection refused` when running outside Docker.
+
+**Cause:** Your `DATABASE_URL` uses `db` as the hostname (the Docker service name), which only resolves inside the Docker network.
+
+**Fix:** When running Alembic locally, use `localhost`:
+
+```bash
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/easyinventory \
+  python -m alembic upgrade head
+```
+
+Or make sure the database container's port is exposed (it is by default in `docker-compose.yml`).
+
+---
+
+### "Role 'postgres' does not exist" or auth errors
+
+**Cause:** The Postgres container was created with different credentials than what you're using.
+
+**Fix:**
+
+```bash
+# Remove the volume and recreate (WARNING: deletes all data)
+docker compose down -v
+docker compose up
+```
+
+---
+
+### Data from another org visible / org isolation broken
+
+**Cause:** A service function is missing the `WHERE org_id = :org_id` filter.
+
+**Fix:** Every business query **must** filter by `org_id`. Check the service function and add the filter. See [Architecture: Multi-Tenancy](architecture.md#multi-tenancy).
+
+---
+
+## Authentication Issues
+
+### `401 Unauthorized` on every request
+
+**Possible causes:**
+
+1. **Token expired** — Cognito tokens expire after 1 hour by default. Get a new token.
+
+2. **Wrong Cognito environment variables:**
+   ```bash
+   # Verify your .env file has the correct values
+   COGNITO_REGION=us-east-2
+   COGNITO_USER_POOL_ID=us-east-2_XXXXXXXXX
+   COGNITO_APP_CLIENT_ID=your-client-id-here
+   ```
+
+3. **Token from wrong User Pool** — If you have multiple Cognito pools (dev, staging, prod), make sure your token matches the pool configured in `.env`.
+
+4. **Malformed Authorization header** — Must be exactly `Authorization: Bearer <token>` (note the space after "Bearer").
+
+---
+
+### `403 Forbidden` — "Insufficient permission"
+
+**Cause:** Your user or org role doesn't have the required permission for the endpoint.
+
+**Debug:**
+
+```bash
+# Check your system role
+curl -s http://localhost:8000/api/me \
+  -H "Authorization: Bearer <token>" | python -m json.tool
+
+# Check your org role
+curl -s http://localhost:8000/api/orgs/me \
+  -H "Authorization: Bearer <token>" | python -m json.tool
+```
+
+See [Architecture: RBAC](architecture.md#role-based-access-control-rbac) for the full permission matrix.
+
+---
+
+### Cognito `AdminCreateUser` fails during invite
+
+**Possible causes:**
+
+1. **Missing AWS credentials** — The API needs AWS credentials with `cognito-idp:AdminCreateUser` permission.
+2. **Wrong region or pool ID** — Double-check `COGNITO_REGION` and `COGNITO_USER_POOL_ID`.
+3. **Email already exists in Cognito** — The invite flow handles this gracefully, but check the Cognito console if you see unexpected errors.
+
+---
+
+### JWKS fetch fails on API startup
+
+**Symptom:** First authenticated request takes a long time or times out.
+
+**Cause:** The API can't reach Cognito's JWKS endpoint.
+
+**Fix:**
+- Check internet connectivity from the server/container.
+- Verify the JWKS URL: `https://cognito-idp.<region>.amazonaws.com/<pool-id>/.well-known/jwks.json`
+- Make sure `COGNITO_REGION` and `COGNITO_USER_POOL_ID` are correct.
+
+---
+
+## Testing Issues
+
+### Suite 1 (`tests/`): "app already started" or fixture errors
+
+**Fix:** Make sure you're not running the dev server while running tests. Alternatively, clear caches:
+
+```bash
+make clean
+make test
+```
+
+---
+
+### Suite 2 (`testsv2/`): "CONNECTION_REFUSED" or database errors
+
+**Cause:** The test database container isn't running.
+
+**Fix:**
+
+```bash
+# Start the test database first
+make test-db
+
+# Wait a few seconds for it to be ready, then run tests
+make test-v2
+```
+
+---
+
+### Suite 2: "Refusing to run tests against a non-test database"
+
+**Cause:** Safety check — `DATABASE_URL` doesn't contain the word "test".
+
+**Fix:** Use the `make test-v2` command which sets the correct `DATABASE_URL` automatically. If running manually:
+
+```bash
+DATABASE_URL=postgresql+asyncpg://test:test@localhost:5433/easyinventory_test \
+  python -m pytest testsv2/ -v
+```
+
+---
+
+### Suite 2: Tests fail with "table does not exist"
+
+**Cause:** Migrations haven't been run on the test database.
+
+**Fix:** `make test-v2` runs migrations automatically. If running manually:
+
+```bash
+DATABASE_URL=postgresql+asyncpg://test:test@localhost:5433/easyinventory_test \
+  python -m alembic upgrade head
+```
+
+---
+
+### Tests pass locally but fail in CI
+
+**Common causes:**
+
+1. **Missing environment variables** — Make sure CI sets all required vars.
+2. **Database not available** — CI needs a Postgres service or container.
+3. **Port conflicts** — Make sure the test database port (5433) is available.
+4. **Cache issues** — Run `make clean` before tests in CI.
+
+---
+
+## API Runtime Errors
+
+### `422 Unprocessable Entity`
+
+**Cause:** Pydantic validation failed. The request body doesn't match the expected schema.
+
+**Debug:** Read the response body — it contains details about which field failed:
+
+```json
+{
+  "detail": [
+    {
+      "loc": ["body", "email"],
+      "msg": "value is not a valid email address",
+      "type": "value_error.email"
+    }
+  ]
+}
+```
+
+**Common mistakes:**
+- Missing required fields
+- Wrong data types (string instead of UUID, integer instead of string)
+- Invalid email format
+- UUID formatted incorrectly
+
+---
+
+### `409 Conflict` when linking supplier to product
+
+**Cause:** The supplier is already linked to this product.
+
+**Fix:** Check existing links before adding:
+
+```bash
+curl -s http://localhost:8000/api/products/<product-id>/suppliers \
+  -H "Authorization: Bearer <token>" | python -m json.tool
+```
+
+If the link exists but is inactive, update it instead of creating a new one:
+
+```bash
+curl -s -X PATCH http://localhost:8000/api/products/<product-id>/suppliers/<supplier-id> \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"is_active": true}'
+```
+
+---
+
+### `500 Internal Server Error`
+
+**Debug:** Check the API logs for the full traceback:
+
+```bash
+# Docker dev
+docker compose logs -f api
+
+# Docker prod
+docker compose --env-file .env.prod -f docker-compose.prod.yml logs -f api
+```
+
+Look for the `X-Request-ID` header in the error response — it can be used to find the specific request in CloudWatch logs.
+
+---
+
+## Deployment Issues
+
+### ECR push fails with "no basic auth credentials"
+
+**Fix:** Re-authenticate with ECR:
+
+```bash
+aws ecr get-login-password --region us-east-1 | \
+  docker login --username AWS --password-stdin \
+  <aws-account-id>.dkr.ecr.us-east-1.amazonaws.com
+```
+
+ECR tokens expire after 12 hours.
+
+---
+
+### `deploy.sh` fails with "Missing .env.prod"
+
+**Fix:** Make sure `.env.prod` exists in the same directory as `deploy.sh`:
+
+```bash
+ls -la .env.prod
+```
+
+---
+
+### Caddy shows "connection refused" for API
+
+**Cause:** The API container isn't running or hasn't started yet.
+
+**Fix:**
+
+```bash
+# Check container status
+docker compose --env-file .env.prod -f docker-compose.prod.yml ps
+
+# Check API logs
+docker compose --env-file .env.prod -f docker-compose.prod.yml logs api
+```
+
+---
+
+### Caddy can't get SSL certificate
+
+**Possible causes:**
+
+1. **DNS not pointed** — A records for your domain and `api.` subdomain must point to your server's IP.
+2. **Ports 80/443 blocked** — Firewall must allow inbound HTTP and HTTPS traffic.
+3. **Rate limited** — Let's Encrypt has [rate limits](https://letsencrypt.org/docs/rate-limits/). Wait and try again.
+
+---
+
+### CloudWatch logs not appearing
+
+**Possible causes:**
+
+1. **IAM permissions** — Server needs `CloudWatchLogsFullAccess` or equivalent.
+2. **AWS credentials** — Must be configured on the server (`aws configure` or instance role).
+3. **Region mismatch** — `AWS_REGION` in `.env.prod` must match where you expect to see logs.
+
+---
+
+## Code Quality Issues
+
+### Black formatting check fails
+
+```bash
+# See which files need formatting
+python -m black --check --diff app/ tests/ testsv2/
+
+# Auto-fix
+make format
+```
+
+---
+
+### mypy type errors
+
+```bash
+# Run mypy to see all errors
+make typecheck
+
+# Common fixes:
+# - Add return type annotations to functions
+# - Add parameter type annotations
+# - Use Optional[str] instead of str | None for Python 3.9 compat
+```
+
+All functions in `app/` must have type annotations. Tests are exempt.
+
+---
+
+## Still Stuck?
+
+1. **Check the logs** — most issues are visible in the API or database logs.
+2. **Check the interactive docs** — visit `http://localhost:8000/docs` to test endpoints directly.
+3. **Clear everything and start fresh:**
+
+   ```bash
+   docker compose down -v
+   make clean
+   docker compose up --build
+   docker compose exec api alembic upgrade head
+   ```
+
+---
+
+## Related Guides
+
+- [Getting Started](getting-started.md) — Setup and installation
+- [Architecture](architecture.md) — How the system works
+- [Developer Guide](developer-guide.md) — Testing and coding standards
+- [Deployment Guide](deployment-guide.md) — Production setup

--- a/tests/functional/test_org_endpoints.py
+++ b/tests/functional/test_org_endpoints.py
@@ -137,6 +137,7 @@ async def test_invite_unknown_email_calls_cognito(app, client):
                         mock_membership_create.return_value = MagicMock(
                             id=uuid.uuid4(),
                             user_id=placeholder_user.id,
+                            email="new@test.com",
                             org_role="ORG_EMPLOYEE",
                             is_active=False,
                             joined_at="2026-03-13T00:00:00+00:00",
@@ -165,6 +166,7 @@ async def test_invite_existing_email_does_not_call_cognito(app, client):
                         mock_create.return_value = MagicMock(
                             id=uuid.uuid4(),
                             user_id=existing_user.id,
+                            email="exists@test.com",
                             org_role="ORG_EMPLOYEE",
                             is_active=True,
                             joined_at="2026-03-13T00:00:00+00:00",

--- a/tests/unit/test_admin_org.py
+++ b/tests/unit/test_admin_org.py
@@ -3,25 +3,25 @@ from unittest.mock import AsyncMock, MagicMock
 
 
 async def test_list_all_orgs_query_executes():
-    """list_all_orgs should execute a query and return results."""
+    """list_all_orgs should execute a query and return Organization models."""
     from app.admin.service import list_all_orgs
 
-    mock_row = MagicMock()
-    mock_row.id = uuid.uuid4()
-    mock_row.name = "Test Org"
-    mock_row.created_at = "2026-03-13T00:00:00+00:00"
-    mock_row.owner_email = "owner@test.com"
-    mock_row.member_count = 3
+    mock_org = MagicMock()
+    mock_org.id = uuid.uuid4()
+    mock_org.name = "Test Org"
+    mock_org.created_at = "2026-03-13T00:00:00+00:00"
+
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = [mock_org]
 
     mock_result = MagicMock()
-    mock_result.all.return_value = [mock_row]
+    mock_result.scalars.return_value = mock_scalars
 
     mock_db = AsyncMock()
     mock_db.execute.return_value = mock_result
 
     result = await list_all_orgs(mock_db)
 
+    assert mock_db.execute.await_count == 1
     assert len(result) == 1
-    assert result[0]["name"] == "Test Org"
-    assert result[0]["owner_email"] == "owner@test.com"
-    assert result[0]["member_count"] == 3
+    assert result[0].name == "Test Org"

--- a/tests/unit/test_org_role_deps.py
+++ b/tests/unit/test_org_role_deps.py
@@ -2,7 +2,7 @@ import uuid
 import pytest
 from unittest.mock import MagicMock
 from fastapi import HTTPException
-from app.orgs.deps import require_org_role
+from app.orgs.deps import RequireOrgRole
 from app.core.roles import OrgRole
 from app.models.org_membership import OrgMembership
 
@@ -15,26 +15,26 @@ def _mock_membership(role=OrgRole.EMPLOYEE):
 
 
 async def test_owner_passes():
-    checker = require_org_role(OrgRole.OWNER, OrgRole.ADMIN)
+    checker = RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)
     result = await checker(membership=_mock_membership(OrgRole.OWNER))
     assert result.org_role == OrgRole.OWNER
 
 
 async def test_admin_passes():
-    checker = require_org_role(OrgRole.OWNER, OrgRole.ADMIN)
+    checker = RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)
     result = await checker(membership=_mock_membership(OrgRole.ADMIN))
     assert result.org_role == OrgRole.ADMIN
 
 
 async def test_employee_fails():
-    checker = require_org_role(OrgRole.OWNER, OrgRole.ADMIN)
+    checker = RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)
     with pytest.raises(HTTPException) as exc_info:
         await checker(membership=_mock_membership(OrgRole.EMPLOYEE))
     assert exc_info.value.status_code == 403
 
 
 async def test_viewer_fails():
-    checker = require_org_role(OrgRole.OWNER, OrgRole.ADMIN)
+    checker = RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)
     with pytest.raises(HTTPException) as exc_info:
         await checker(membership=_mock_membership(OrgRole.VIEWER))
     assert exc_info.value.status_code == 403

--- a/tests/unit/test_role_deps.py
+++ b/tests/unit/test_role_deps.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 from fastapi import HTTPException
 
-from app.auth.deps import require_role
+from app.auth.deps import RequireRole
 from app.core.roles import SystemRole
 from app.models.user import User
 
@@ -15,16 +15,16 @@ def _mock_user(role: str = SystemRole.USER) -> MagicMock:
 
 
 async def test_admin_passes_admin_check():
-    """SYSTEM_ADMIN should pass require_role('SYSTEM_ADMIN')."""
-    checker = require_role(SystemRole.ADMIN)
+    """SYSTEM_ADMIN should pass RequireRole('SYSTEM_ADMIN')."""
+    checker = RequireRole(SystemRole.ADMIN)
     user = _mock_user(role=SystemRole.ADMIN)
     result = await checker(current_user=user)
     assert result == user
 
 
 async def test_regular_user_fails_admin_check():
-    """SYSTEM_USER should be rejected by require_role('SYSTEM_ADMIN')."""
-    checker = require_role(SystemRole.ADMIN)
+    """SYSTEM_USER should be rejected by RequireRole('SYSTEM_ADMIN')."""
+    checker = RequireRole(SystemRole.ADMIN)
     user = _mock_user(role=SystemRole.USER)
     with pytest.raises(HTTPException) as exc_info:
         await checker(current_user=user)
@@ -34,7 +34,7 @@ async def test_regular_user_fails_admin_check():
 
 async def test_multiple_allowed_roles():
     """User with any of the allowed roles should pass."""
-    checker = require_role(SystemRole.ADMIN, SystemRole.USER)
+    checker = RequireRole(SystemRole.ADMIN, SystemRole.USER)
     user = _mock_user(role=SystemRole.USER)
     result = await checker(current_user=user)
     assert result == user
@@ -42,7 +42,7 @@ async def test_multiple_allowed_roles():
 
 async def test_unknown_role_fails():
     """A role not in the allowed list should be rejected."""
-    checker = require_role(SystemRole.ADMIN)
+    checker = RequireRole(SystemRole.ADMIN)
     user = _mock_user(role="UNKNOWN_ROLE")
     with pytest.raises(HTTPException) as exc_info:
         await checker(current_user=user)
@@ -50,8 +50,8 @@ async def test_unknown_role_fails():
 
 
 async def test_returns_user_on_success():
-    """require_role should return the user object, not just pass."""
-    checker = require_role(SystemRole.USER)
+    """RequireRole should return the user object, not just pass."""
+    checker = RequireRole(SystemRole.USER)
     user = _mock_user(role=SystemRole.USER)
     result = await checker(current_user=user)
     assert result.email == "test@test.com"


### PR DESCRIPTION
## What
Three related refactors to clean up the service → route boundary and dependency injection:

1. **Service layer now returns SQLAlchemy models everywhere** — service.py, service.py no longer build dicts; they return `OrgMembership`, `Organization`, and `User` models directly.
2. **Routes handle all serialization** — computed fields like `owner_email`, `member_count`, and `org_count` are now built in the route layer using Pydantic schemas, not in services.
3. **Closure-factory dependencies replaced with callable classes** — `require_role()` → `RequireRole()`, `require_org_role()` → `RequireOrgRole()`. Same usage via `Depends()`, no nested functions.

Supporting changes:
- Added `email` property to `OrgMembership` model (delegates to `self.user.email`) for seamless `from_attributes=True` serialization.
- Updated 3 failing tests to match the new return types.
- Updated all docs to reflect the refactored code.
- Scrubbed a real Cognito User Pool ID from deployment-guide.md and .env.prod.
- Updated branching model in developer guide (`development` → `main`).

## Why
- Services returning dicts coupled them to specific response shapes, making reuse harder and violating the pattern where services are pure data access.
- Closure factories with nested `async def` were harder to read than equivalent callable classes.
- Docs had stale references after the refactoring.

## How to test
1. `make test` — all 197 tests pass
2. `make lint` — black + mypy clean
3. Review service.py, service.py — all functions return ORM models
4. Review routes.py, routes_orgs.py, routes_users.py — serialization happens here
5. Review deps.py, deps.py — `RequireRole` / `RequireOrgRole` are now classes
6. `grep -r 'Fc70cHz7B' .` — returns nothing (credential scrubbed)

## Checklist
- [x] `make test` passes
- [x] `make lint` passes (black + mypy)
- [x] No hardcoded secrets or credentials
- [ ] New env vars added to .env.example
- [x] README updated if needed