### PR TITLE
Run Alembic migrations automatically on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--access-log"]
+RUN chmod +x entrypoint.sh
+
+CMD ["./entrypoint.sh"]

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -10,9 +10,11 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt gunicorn uvicorn
 
 COPY . .
+RUN chmod +x entrypoint.prod.sh
 
 EXPOSE 8000
 
+ENTRYPOINT ["./entrypoint.prod.sh"]
 CMD ["gunicorn", "app.main:app", \
      "-w", "2", \
      "-k", "uvicorn.workers.UvicornWorker", \

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,9 +31,6 @@ docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull api
 echo "Restarting api container"
 docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d api
 
-echo "Running database migrations"
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" exec -T api alembic upgrade head
-
 echo "Pruning dangling images"
 docker image prune -f
 

--- a/entrypoint.prod.sh
+++ b/entrypoint.prod.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+echo "Waiting for database..."
+while ! python -c "
+import asyncio, asyncpg, os, re
+url = os.environ['DATABASE_URL']
+# Convert SQLAlchemy URL to asyncpg format
+url = re.sub(r'^postgresql\+asyncpg://', 'postgresql://', url)
+asyncio.run(asyncpg.connect(url))
+" 2>/dev/null; do
+  echo "  DB not ready, retrying in 2s..."
+  sleep 2
+done
+echo "Database is ready"
+
+echo "Running database migrations..."
+alembic upgrade head
+
+echo "Starting application..."
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+alembic upgrade head
+
+echo "Starting application..."
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --access-log


### PR DESCRIPTION
## What
Add entrypoint scripts to dev and prod Docker images that run [alembic upgrade head](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%203.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) automatically before the application starts. The prod entrypoint also waits for Postgres to be ready before attempting migrations.

## Why
On a fresh docker compose up, the API container would start and attempt to query tables that didn't exist yet, resulting in relation "users" does not exist errors. In production, there was a race window between the container restarting and `deploy.sh` running migrations via docker exec, where requests could hit the API before tables were migrated.

## How to test

1. Remove existing volumes: docker compose down -v
2. Start fresh: docker compose up --build
3. Confirm logs show Running database migrations... followed by Alembic output before Starting application...
4. Confirm no relation does not exist errors in the logs
5. Verify the API responds: `curl http://localhost:8000/health`

## Checklist
- [x] `make test` passes
- [x] `make lint` passes (black + mypy)
- [x] No hardcoded secrets or credentials
- [x] New env vars added to .env.example
- [x] README updated if needed