### PR TITLE
feat: LayoutVersion model and CRUD

### DIFF
--- a/alembic/versions/d1e2f3a4b5c6_add_layout_versions.py
+++ b/alembic/versions/d1e2f3a4b5c6_add_layout_versions.py
@@ -1,0 +1,69 @@
+"""Add layout_versions table.
+
+Revision ID: d1e2f3a4b5c6
+Revises: c1d2e3f4a5b6
+Create Date: 2026-03-31 10:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers
+revision = "d1e2f3a4b5c6"
+down_revision = "c1d2e3f4a5b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "layout_versions",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "store_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("version_number", sa.Integer(), nullable=False),
+        sa.Column("rows", sa.Integer(), nullable=False),
+        sa.Column("cols", sa.Integer(), nullable=False),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["store_id"],
+            ["stores.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("store_id", "version_number", name="uq_layout_versions_store_version"),
+    )
+    op.create_index("ix_layout_versions_store_id", "layout_versions", ["store_id"])
+    op.create_index("ix_layout_versions_is_active", "layout_versions", ["is_active"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_layout_versions_is_active", table_name="layout_versions")
+    op.drop_index("ix_layout_versions_store_id", table_name="layout_versions")
+    op.drop_table("layout_versions")

--- a/app/layouts/__init__.py
+++ b/app/layouts/__init__.py
@@ -1,0 +1,1 @@
+"""Layouts package."""

--- a/app/layouts/routes.py
+++ b/app/layouts/routes.py
@@ -13,6 +13,7 @@ from app.models.store import Store
 from app.orgs.deps import RequireOrgRole
 from app.stores.deps import get_store_from_path
 from app.layouts.schemas import LayoutVersionCreate, LayoutVersionRead
+from app.models.layout_version import LayoutVersion
 from app.layouts import service
 
 router = APIRouter(prefix="/api/stores/{store_id}/layouts", tags=["layouts"])
@@ -24,10 +25,10 @@ router = APIRouter(prefix="/api/stores/{store_id}/layouts", tags=["layouts"])
 async def list_layout_versions(
     db: AsyncSession = Depends(get_db),
     store: Store = Depends(get_store_from_path),
-) -> list[LayoutVersionRead]:
+) -> list[LayoutVersion]:
     """Return all layout versions for the store ordered by version_number."""
     versions = await service.list_layout_versions(db, store.id)
-    return [LayoutVersionRead.model_validate(v) for v in versions]
+    return versions
 
 
 # NOTE: /active must be declared before /{layout_id} to avoid routing conflict.
@@ -35,10 +36,10 @@ async def list_layout_versions(
 async def get_active_layout(
     db: AsyncSession = Depends(get_db),
     store: Store = Depends(get_store_from_path),
-) -> LayoutVersionRead:
+) -> LayoutVersion:
     """Return the currently active layout version with zones eagerly loaded."""
     layout = await service.get_active_layout(db, store.id)
-    return LayoutVersionRead.model_validate(layout)
+    return layout
 
 
 # ── Write endpoints (OWNER or ADMIN only) ─────────────────────────────────────
@@ -50,10 +51,10 @@ async def create_layout_version(
     db: AsyncSession = Depends(get_db),
     store: Store = Depends(get_store_from_path),
     _: object = Depends(RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)),
-) -> LayoutVersionRead:
+) -> LayoutVersion:
     """Create a new layout version with an auto-incremented version_number."""
     layout = await service.create_layout_version(db, store.id, data.rows, data.cols)
-    return LayoutVersionRead.model_validate(layout)
+    return layout
 
 
 @router.post("/{layout_id}/activate", response_model=LayoutVersionRead)
@@ -62,7 +63,7 @@ async def activate_layout_version(
     db: AsyncSession = Depends(get_db),
     store: Store = Depends(get_store_from_path),
     _: object = Depends(RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)),
-) -> LayoutVersionRead:
+) -> LayoutVersion:
     """Activate a layout version, deactivating all others for the store."""
     layout = await service.activate_layout_version(db, layout_id, store.id)
-    return LayoutVersionRead.model_validate(layout)
+    return layout

--- a/app/layouts/routes.py
+++ b/app/layouts/routes.py
@@ -1,4 +1,5 @@
 """Routes for LayoutVersion CRUD operations."""
+
 from __future__ import annotations
 
 import uuid

--- a/app/layouts/routes.py
+++ b/app/layouts/routes.py
@@ -1,0 +1,67 @@
+"""Routes for LayoutVersion CRUD operations."""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.roles import OrgRole
+from app.models.store import Store
+from app.orgs.deps import RequireOrgRole
+from app.stores.deps import get_store_from_path
+from app.layouts.schemas import LayoutVersionCreate, LayoutVersionRead
+from app.layouts import service
+
+router = APIRouter(prefix="/api/stores/{store_id}/layouts", tags=["layouts"])
+
+# ── Read endpoints (all org members) ──────────────────────────────────────────
+
+
+@router.get("", response_model=list[LayoutVersionRead])
+async def list_layout_versions(
+    db: AsyncSession = Depends(get_db),
+    store: Store = Depends(get_store_from_path),
+) -> list[LayoutVersionRead]:
+    """Return all layout versions for the store ordered by version_number."""
+    versions = await service.list_layout_versions(db, store.id)
+    return [LayoutVersionRead.model_validate(v) for v in versions]
+
+
+# NOTE: /active must be declared before /{layout_id} to avoid routing conflict.
+@router.get("/active", response_model=LayoutVersionRead)
+async def get_active_layout(
+    db: AsyncSession = Depends(get_db),
+    store: Store = Depends(get_store_from_path),
+) -> LayoutVersionRead:
+    """Return the currently active layout version with zones eagerly loaded."""
+    layout = await service.get_active_layout(db, store.id)
+    return LayoutVersionRead.model_validate(layout)
+
+
+# ── Write endpoints (OWNER or ADMIN only) ─────────────────────────────────────
+
+
+@router.post("", response_model=LayoutVersionRead, status_code=status.HTTP_201_CREATED)
+async def create_layout_version(
+    data: LayoutVersionCreate,
+    db: AsyncSession = Depends(get_db),
+    store: Store = Depends(get_store_from_path),
+    _: object = Depends(RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)),
+) -> LayoutVersionRead:
+    """Create a new layout version with an auto-incremented version_number."""
+    layout = await service.create_layout_version(db, store.id, data.rows, data.cols)
+    return LayoutVersionRead.model_validate(layout)
+
+
+@router.post("/{layout_id}/activate", response_model=LayoutVersionRead)
+async def activate_layout_version(
+    layout_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    store: Store = Depends(get_store_from_path),
+    _: object = Depends(RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)),
+) -> LayoutVersionRead:
+    """Activate a layout version, deactivating all others for the store."""
+    layout = await service.activate_layout_version(db, layout_id, store.id)
+    return LayoutVersionRead.model_validate(layout)

--- a/app/layouts/schemas.py
+++ b/app/layouts/schemas.py
@@ -1,4 +1,5 @@
 """Pydantic schemas for LayoutVersion."""
+
 from __future__ import annotations
 
 import uuid

--- a/app/layouts/schemas.py
+++ b/app/layouts/schemas.py
@@ -1,0 +1,32 @@
+"""Pydantic schemas for LayoutVersion."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class LayoutVersionCreate(BaseModel):
+    """Payload for creating a new layout version."""
+
+    rows: int = Field(..., ge=2, le=30, description="Number of rows (2–30)")
+    cols: int = Field(..., ge=2, le=30, description="Number of columns (2–30)")
+
+
+class LayoutVersionRead(BaseModel):
+    """Full representation of a layout version returned from the API."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    store_id: uuid.UUID
+    version_number: int
+    rows: int
+    cols: int
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+    # Relationship stubs — populated in BE-07 (zones) and BE-08 (fixtures)
+    zones: list = []
+    fixtures: list = []

--- a/app/layouts/service.py
+++ b/app/layouts/service.py
@@ -77,6 +77,8 @@ async def get_active_layout(
     store_id: uuid.UUID,
 ) -> LayoutVersion:
     """Return the currently active layout version for the store."""
+    # TODO(BE-07): add .options(selectinload(LayoutVersion.zones)) once the Zone
+    #              model and relationship are introduced in the zones-cellset PR.
     stmt = (
         select(LayoutVersion)
         .where(

--- a/app/layouts/service.py
+++ b/app/layouts/service.py
@@ -1,0 +1,107 @@
+"""Service layer for LayoutVersion CRUD operations."""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.core.exceptions import NotFound
+from app.models.layout_version import LayoutVersion
+
+
+async def create_layout_version(
+    db: AsyncSession,
+    store_id: uuid.UUID,
+    rows: int,
+    cols: int,
+) -> LayoutVersion:
+    """Create a new layout version with an auto-incremented version_number."""
+    # Compute next version_number as MAX(version_number) + 1, starting at 1
+    subq = select(
+        func.coalesce(func.max(LayoutVersion.version_number), 0) + 1
+    ).where(LayoutVersion.store_id == store_id)
+    result = await db.execute(subq)
+    next_version = result.scalar_one()
+
+    layout = LayoutVersion(
+        store_id=store_id,
+        version_number=next_version,
+        rows=rows,
+        cols=cols,
+        is_active=False,
+    )
+    db.add(layout)
+    await db.flush()
+    await db.refresh(layout)
+    return layout
+
+
+async def activate_layout_version(
+    db: AsyncSession,
+    layout_id: uuid.UUID,
+    store_id: uuid.UUID,
+) -> LayoutVersion:
+    """Deactivate all versions for the store, then activate the specified one."""
+    # Verify the target version exists and belongs to the store
+    stmt = select(LayoutVersion).where(
+        LayoutVersion.id == layout_id,
+        LayoutVersion.store_id == store_id,
+    )
+    result = await db.execute(stmt)
+    layout = result.scalar_one_or_none()
+    if layout is None:
+        raise NotFound(f"Layout version {layout_id} not found for store {store_id}")
+
+    # Deactivate all versions for this store
+    await db.execute(
+        update(LayoutVersion)
+        .where(LayoutVersion.store_id == store_id)
+        .values(is_active=False)
+    )
+
+    # Activate the target version
+    await db.execute(
+        update(LayoutVersion)
+        .where(LayoutVersion.id == layout_id)
+        .values(is_active=True)
+    )
+
+    await db.flush()
+    await db.refresh(layout)
+    return layout
+
+
+async def get_active_layout(
+    db: AsyncSession,
+    store_id: uuid.UUID,
+) -> LayoutVersion:
+    """Return the currently active layout version with zones eagerly loaded."""
+    stmt = (
+        select(LayoutVersion)
+        .where(
+            LayoutVersion.store_id == store_id,
+            LayoutVersion.is_active == True,  # noqa: E712
+        )
+        .options(selectinload(LayoutVersion.zones))
+    )
+    result = await db.execute(stmt)
+    layout = result.scalar_one_or_none()
+    if layout is None:
+        raise NotFound(f"No active layout version found for store {store_id}")
+    return layout
+
+
+async def list_layout_versions(
+    db: AsyncSession,
+    store_id: uuid.UUID,
+) -> list[LayoutVersion]:
+    """Return all layout versions for the store ordered by version_number."""
+    stmt = (
+        select(LayoutVersion)
+        .where(LayoutVersion.store_id == store_id)
+        .order_by(LayoutVersion.version_number.asc())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())

--- a/app/layouts/service.py
+++ b/app/layouts/service.py
@@ -5,7 +5,6 @@ import uuid
 
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from app.core.exceptions import NotFound
 from app.models.layout_version import LayoutVersion
@@ -77,14 +76,13 @@ async def get_active_layout(
     db: AsyncSession,
     store_id: uuid.UUID,
 ) -> LayoutVersion:
-    """Return the currently active layout version with zones eagerly loaded."""
+    """Return the currently active layout version for the store."""
     stmt = (
         select(LayoutVersion)
         .where(
             LayoutVersion.store_id == store_id,
             LayoutVersion.is_active == True,  # noqa: E712
         )
-        .options(selectinload(LayoutVersion.zones))
     )
     result = await db.execute(stmt)
     layout = result.scalar_one_or_none()

--- a/app/layouts/service.py
+++ b/app/layouts/service.py
@@ -1,4 +1,5 @@
 """Service layer for LayoutVersion CRUD operations."""
+
 from __future__ import annotations
 
 import uuid
@@ -18,9 +19,9 @@ async def create_layout_version(
 ) -> LayoutVersion:
     """Create a new layout version with an auto-incremented version_number."""
     # Compute next version_number as MAX(version_number) + 1, starting at 1
-    subq = select(
-        func.coalesce(func.max(LayoutVersion.version_number), 0) + 1
-    ).where(LayoutVersion.store_id == store_id)
+    subq = select(func.coalesce(func.max(LayoutVersion.version_number), 0) + 1).where(
+        LayoutVersion.store_id == store_id
+    )
     result = await db.execute(subq)
     next_version = result.scalar_one()
 
@@ -79,12 +80,9 @@ async def get_active_layout(
     """Return the currently active layout version for the store."""
     # TODO(BE-07): add .options(selectinload(LayoutVersion.zones)) once the Zone
     #              model and relationship are introduced in the zones-cellset PR.
-    stmt = (
-        select(LayoutVersion)
-        .where(
-            LayoutVersion.store_id == store_id,
-            LayoutVersion.is_active == True,  # noqa: E712
-        )
+    stmt = select(LayoutVersion).where(
+        LayoutVersion.store_id == store_id,
+        LayoutVersion.is_active == True,  # noqa: E712
     )
     result = await db.execute(stmt)
     layout = result.scalar_one_or_none()

--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ from app.orgs.routes import router as orgs_router
 from app.admin.routes_orgs import router as admin_orgs_router
 from app.admin.routes_users import router as admin_users_router
 from app.health.routes import router as health_router
+from app.layouts.routes import router as layouts_router
 from app.products.routes import router as products_router
 from app.stores.routes import router as stores_router
 from app.suppliers.routes import router as suppliers_router
@@ -83,6 +84,7 @@ def create_app() -> FastAPI:
     app.include_router(suppliers_router)
     app.include_router(products_router)
     app.include_router(stores_router)
+    app.include_router(layouts_router)
 
     return app
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.supplier import Supplier
 from app.models.product import Product
 from app.models.product_supplier import ProductSupplier
 from app.models.store import Store
+from app.models.layout_version import LayoutVersion
 
 __all__ = [
     "BaseModel",
@@ -16,4 +17,5 @@ __all__ = [
     "Product",
     "ProductSupplier",
     "Store",
+    "LayoutVersion",
 ]

--- a/app/models/layout_version.py
+++ b/app/models/layout_version.py
@@ -3,16 +3,12 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import BaseModel
-
-if TYPE_CHECKING:
-    from app.models.zone import Zone
 
 
 class LayoutVersion(BaseModel):
@@ -37,11 +33,4 @@ class LayoutVersion(BaseModel):
         onupdate=func.now(),
         nullable=False,
     )
-
-    # Relationship stub — Zone model added in BE-07
-    zones: Mapped[list["Zone"]] = relationship(
-        "Zone",
-        back_populates="layout_version",
-        lazy="selectin",
-        cascade="all, delete-orphan",
-    )
+    # zones relationship added in BE-07 once the Zone model exists

--- a/app/models/layout_version.py
+++ b/app/models/layout_version.py
@@ -33,4 +33,5 @@ class LayoutVersion(BaseModel):
         onupdate=func.now(),
         nullable=False,
     )
-    # zones relationship added in BE-07 once the Zone model exists
+    # TODO(BE-07): add `zones` relationship once Zone model is defined in the
+    #              zones-cellset PR (back_populates="layout_version", lazy="selectin").

--- a/app/models/layout_version.py
+++ b/app/models/layout_version.py
@@ -1,0 +1,47 @@
+"""LayoutVersion model."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import BaseModel
+
+if TYPE_CHECKING:
+    from app.models.zone import Zone
+
+
+class LayoutVersion(BaseModel):
+    """Represents a versioned layout configuration for a store grid."""
+
+    __tablename__ = "layout_versions"
+    __table_args__ = (UniqueConstraint("store_id", "version_number", name="uq_layout_versions_store_version"),)
+
+    store_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("stores.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    version_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    rows: Mapped[int] = mapped_column(Integer, nullable=False)
+    cols: Mapped[int] = mapped_column(Integer, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, index=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    # Relationship stub — Zone model added in BE-07
+    zones: Mapped[list["Zone"]] = relationship(
+        "Zone",
+        back_populates="layout_version",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+    )

--- a/app/models/layout_version.py
+++ b/app/models/layout_version.py
@@ -1,4 +1,5 @@
 """LayoutVersion model."""
+
 from __future__ import annotations
 
 import uuid
@@ -15,7 +16,11 @@ class LayoutVersion(BaseModel):
     """Represents a versioned layout configuration for a store grid."""
 
     __tablename__ = "layout_versions"
-    __table_args__ = (UniqueConstraint("store_id", "version_number", name="uq_layout_versions_store_version"),)
+    __table_args__ = (
+        UniqueConstraint(
+            "store_id", "version_number", name="uq_layout_versions_store_version"
+        ),
+    )
 
     store_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
@@ -26,7 +31,9 @@ class LayoutVersion(BaseModel):
     version_number: Mapped[int] = mapped_column(Integer, nullable=False)
     rows: Mapped[int] = mapped_column(Integer, nullable=False)
     cols: Mapped[int] = mapped_column(Integer, nullable=False)
-    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, index=True)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, index=True
+    )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -18,6 +18,7 @@ Complete reference for every endpoint in the EasyInventory API. All routes retur
 - [Products](#products)
 - [Product–Supplier Links](#productsupplier-links)
 - [Stores](#stores)
+- [Layout Versions](#layout-versions)
 - [Admin: Organizations](#admin-organizations)
 - [Admin: Users](#admin-users)
 - [Invite Flow Details](#invite-flow-details)
@@ -671,6 +672,143 @@ Creates a new store within the current organization.
 **Errors:**
 - `403` — Caller is not the org owner.
 - `422` — Missing or empty `name`.
+
+---
+
+## Layout Versions
+
+Layout versions represent versioned grid configurations for a store. Each version defines a rows × cols grid. Only one version can be active at a time per store. Zones (BE-07) and fixtures (BE-08) are nested within a layout version.
+
+**All layout endpoints require a valid `X-Org-Id` header** and validate that `store_id` belongs to the caller's organization.
+
+---
+
+### `GET /api/stores/{store_id}/layouts`
+
+Returns all layout versions for the store ordered by `version_number` ascending.
+
+**Auth:** Required — any org member  
+**Response** `200`
+
+```json
+[
+  {
+    "id": "layout-uuid",
+    "store_id": "store-uuid",
+    "version_number": 1,
+    "rows": 10,
+    "cols": 8,
+    "is_active": false,
+    "created_at": "2026-03-31T10:00:00Z",
+    "updated_at": "2026-03-31T10:00:00Z",
+    "zones": [],
+    "fixtures": []
+  }
+]
+```
+
+**Errors:**
+- `404` — Store not found in the current org.
+
+---
+
+### `GET /api/stores/{store_id}/layouts/active`
+
+Returns the currently active layout version with zones and fixtures eagerly loaded.
+
+**Auth:** Required — any org member  
+**Response** `200`
+
+```json
+{
+  "id": "layout-uuid",
+  "store_id": "store-uuid",
+  "version_number": 2,
+  "rows": 10,
+  "cols": 8,
+  "is_active": true,
+  "created_at": "2026-03-31T10:00:00Z",
+  "updated_at": "2026-03-31T11:00:00Z",
+  "zones": [],
+  "fixtures": []
+}
+```
+
+**Errors:**
+- `404` — No active layout version exists for the store.
+- `404` — Store not found in the current org.
+
+---
+
+### `POST /api/stores/{store_id}/layouts`
+
+Creates a new layout version. The `version_number` is auto-incremented (starts at 1, increments by 1 for each subsequent version). New versions are inactive by default.
+
+**Auth:** Required — `ORG_OWNER` or `ORG_ADMIN`  
+**Request Body**
+
+```json
+{
+  "rows": 10,
+  "cols": 8
+}
+```
+
+| Field | Type | Required | Constraints | Description |
+|---|---|---|---|---|
+| `rows` | integer | Yes | min 2, max 30 | Number of grid rows |
+| `cols` | integer | Yes | min 2, max 30 | Number of grid columns |
+
+**Response** `201`
+
+```json
+{
+  "id": "layout-uuid",
+  "store_id": "store-uuid",
+  "version_number": 1,
+  "rows": 10,
+  "cols": 8,
+  "is_active": false,
+  "created_at": "2026-03-31T10:00:00Z",
+  "updated_at": "2026-03-31T10:00:00Z",
+  "zones": [],
+  "fixtures": []
+}
+```
+
+**Errors:**
+- `403` — Caller is not `ORG_OWNER` or `ORG_ADMIN`.
+- `404` — Store not found in the current org.
+- `422` — `rows` or `cols` is outside the 2–30 range.
+
+---
+
+### `POST /api/stores/{store_id}/layouts/{layout_id}/activate`
+
+Activates the specified layout version and deactivates all other versions for the store.
+
+**Auth:** Required — `ORG_OWNER` or `ORG_ADMIN`  
+**Response** `200` — Returns the now-active layout version.
+
+```json
+{
+  "id": "layout-uuid",
+  "store_id": "store-uuid",
+  "version_number": 2,
+  "rows": 10,
+  "cols": 8,
+  "is_active": true,
+  "created_at": "2026-03-31T10:00:00Z",
+  "updated_at": "2026-03-31T11:00:00Z",
+  "zones": [],
+  "fixtures": []
+}
+```
+
+**Errors:**
+- `403` — Caller is not `ORG_OWNER` or `ORG_ADMIN`.
+- `404` — Layout version not found for the store.
+- `404` — Store not found in the current org.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,6 +67,11 @@ easyinventory-api/
 │   │   ├── schemas.py           #   Store Pydantic schemas
 │   │   └── service.py           #   Store data access
 │   │
+│   ├── layouts/                 # Layout versions domain
+│   │   ├── routes.py            #   Layout CRUD + activate endpoints (store-scoped)
+│   │   ├── schemas.py           #   LayoutVersionCreate / LayoutVersionRead schemas
+│   │   └── service.py           #   Layout data access (create, activate, list, get active)
+│   │
 │   ├── suppliers/               # Suppliers domain
 │   │   ├── routes.py            #   Supplier CRUD endpoints
 │   │   ├── schemas.py           #   Supplier Pydantic schemas
@@ -93,7 +98,8 @@ easyinventory-api/
 │       ├── supplier.py          #   Supplier (org-scoped, contact info)
 │       ├── product.py           #   Product (org-scoped, SKU, category)
 │       ├── product_supplier.py  #   ProductSupplier join table (is_active flag)
-│       └── store.py             #   Store (org-scoped, is_active, updated_at)
+│       ├── store.py             #   Store (org-scoped, is_active, updated_at)
+│       └── layout_version.py    #   LayoutVersion (store-scoped, version_number, rows, cols, is_active)
 │
 ├── alembic/                     # Database migration infrastructure
 │   ├── env.py                   #   Async migration runner (reads DATABASE_URL)
@@ -459,7 +465,8 @@ All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which
 | `Supplier` | `suppliers` | `org_id` (FK), `name`, `contact_name`, `contact_email`, `contact_phone`, `notes` | — |
 | `Product` | `products` | `org_id` (FK), `name`, `description`, `sku`, `category` | → `ProductSupplier` (one-to-many) |
 | `ProductSupplier` | `product_suppliers` | `product_id` (FK), `supplier_id` (FK), `is_active` | → `Supplier` / Unique on `(product_id, supplier_id)` |
-| `Store` | `stores` | `org_id` (FK, CASCADE), `name`, `is_active`, `updated_at` | — |
+| `Store` | `stores` | `org_id` (FK, CASCADE), `name`, `is_active`, `updated_at` | → `LayoutVersion` (one-to-many) |
+| `LayoutVersion` | `layout_versions` | `store_id` (FK, CASCADE), `version_number`, `rows`, `cols`, `is_active`, `updated_at` | Unique on `(store_id, version_number)` |
 
 ### Key design decisions
 
@@ -469,6 +476,7 @@ All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which
 - **Soft state on stores** — `Store.is_active` allows deactivating stores without deleting them or their future inventory records.
 - **Join table with metadata** — `ProductSupplier` is not just a simple many-to-many join. It has an `is_active` flag, allowing you to deactivate a specific product-supplier relationship without removing it.
 - **Cascade deletes** — `Store.org_id` is defined with `ondelete="CASCADE"`, so all stores are deleted automatically when their parent organization is deleted.
+- **Layout versioning** — `LayoutVersion` models a point-in-time grid configuration for a store. Versions are immutable once created (grid dimensions cannot be changed), and only one may be `is_active=True` at a time. The `activate` endpoint uses a bulk `UPDATE … SET is_active=False` across the store, then a targeted `UPDATE … SET is_active=True` on the target, making activation atomic within the transaction.
 
 ---
 

--- a/testsv2/factories.py
+++ b/testsv2/factories.py
@@ -11,6 +11,7 @@ import uuid
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.roles import OrgRole, SystemRole
+from app.models.layout_version import LayoutVersion
 from app.models.organization import Organization
 from app.models.org_membership import OrgMembership
 from app.models.product import Product
@@ -174,3 +175,25 @@ async def create_store(
     db.add(store)
     await db.flush()
     return store
+
+
+async def create_layout_version(
+    db: AsyncSession,
+    *,
+    store_id: uuid.UUID,
+    rows: int = 5,
+    cols: int = 5,
+    version_number: int = 1,
+    is_active: bool = False,
+) -> LayoutVersion:
+    """Insert a ``LayoutVersion`` row and return it."""
+    layout = LayoutVersion(
+        store_id=store_id,
+        rows=rows,
+        cols=cols,
+        version_number=version_number,
+        is_active=is_active,
+    )
+    db.add(layout)
+    await db.flush()
+    return layout

--- a/testsv2/functional/test_layout_endpoints.py
+++ b/testsv2/functional/test_layout_endpoints.py
@@ -40,7 +40,9 @@ async def test_create_layout_version_returns_201(
 ) -> None:
     """Owner can create a layout version; response is 201 with correct payload."""
     org = await create_org(db)
-    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
     store = await create_store(db, org_id=org.id)
 
     response = await client.post(
@@ -67,7 +69,9 @@ async def test_create_layout_version_increments_version_number(
 ) -> None:
     """Second version gets version_number 2."""
     org = await create_org(db)
-    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
     store = await create_store(db, org_id=org.id)
 
     await client.post(
@@ -93,7 +97,9 @@ async def test_create_layout_version_rejects_rows_below_minimum(
 ) -> None:
     """rows < 2 returns 422 Unprocessable Entity."""
     org = await create_org(db)
-    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
     store = await create_store(db, org_id=org.id)
 
     response = await client.post(
@@ -113,7 +119,9 @@ async def test_create_layout_version_rejects_cols_above_maximum(
 ) -> None:
     """cols > 30 returns 422 Unprocessable Entity."""
     org = await create_org(db)
-    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
     store = await create_store(db, org_id=org.id)
 
     response = await client.post(
@@ -133,7 +141,9 @@ async def test_create_layout_version_forbidden_for_viewer(
 ) -> None:
     """Viewer role cannot create a layout version; returns 403."""
     org = await create_org(db)
-    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.VIEWER)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.VIEWER
+    )
     store = await create_store(db, org_id=org.id)
 
     response = await client.post(
@@ -156,10 +166,16 @@ async def test_activate_sets_version_active_and_deactivates_others(
 ) -> None:
     """Activating one version deactivates all others for the same store."""
     org = await create_org(db)
-    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
     store = await create_store(db, org_id=org.id)
-    v1 = await create_layout_version(db, store_id=store.id, version_number=1, is_active=True)
-    v2 = await create_layout_version(db, store_id=store.id, version_number=2, is_active=False)
+    v1 = await create_layout_version(
+        db, store_id=store.id, version_number=1, is_active=True
+    )
+    v2 = await create_layout_version(
+        db, store_id=store.id, version_number=2, is_active=False
+    )
 
     response = await client.post(
         f"/api/stores/{store.id}/layouts/{v2.id}/activate",
@@ -191,7 +207,9 @@ async def test_activate_unknown_layout_returns_404(
     import uuid
 
     org = await create_org(db)
-    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
     store = await create_store(db, org_id=org.id)
 
     response = await client.post(
@@ -213,7 +231,9 @@ async def test_get_active_layout_returns_active_version(
 ) -> None:
     """Returns the active layout version with an empty zones list."""
     org = await create_org(db)
-    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE
+    )
     store = await create_store(db, org_id=org.id)
     active = await create_layout_version(
         db, store_id=store.id, version_number=1, rows=4, cols=6, is_active=True
@@ -241,10 +261,14 @@ async def test_get_active_layout_returns_404_when_none_active(
 ) -> None:
     """Returns 404 when no layout version is active for the store."""
     org = await create_org(db)
-    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE
+    )
     store = await create_store(db, org_id=org.id)
     # Create an inactive version only
-    await create_layout_version(db, store_id=store.id, version_number=1, is_active=False)
+    await create_layout_version(
+        db, store_id=store.id, version_number=1, is_active=False
+    )
 
     response = await client.get(
         f"/api/stores/{store.id}/layouts/active",
@@ -265,7 +289,9 @@ async def test_list_layout_versions_ordered_by_version_number(
 ) -> None:
     """Returns all versions ordered ascending by version_number."""
     org = await create_org(db)
-    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE
+    )
     store = await create_store(db, org_id=org.id)
     # Insert out of order to verify sorting
     await create_layout_version(db, store_id=store.id, version_number=3)
@@ -290,7 +316,9 @@ async def test_list_layout_versions_empty(
 ) -> None:
     """Returns an empty list when the store has no layout versions."""
     org = await create_org(db)
-    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE
+    )
     store = await create_store(db, org_id=org.id)
 
     response = await client.get(
@@ -310,7 +338,9 @@ async def test_list_layout_versions_scoped_to_store(
 ) -> None:
     """Versions from other stores are not included."""
     org = await create_org(db)
-    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
     store_a = await create_store(db, org_id=org.id, name="Store A")
     store_b = await create_store(db, org_id=org.id, name="Store B")
     target = await create_layout_version(db, store_id=store_a.id, version_number=1)

--- a/testsv2/functional/test_layout_endpoints.py
+++ b/testsv2/functional/test_layout_endpoints.py
@@ -1,0 +1,326 @@
+"""
+Functional tests for the layout version routes.
+
+  POST   /api/stores/{store_id}/layouts
+  POST   /api/stores/{store_id}/layouts/{id}/activate
+  GET    /api/stores/{store_id}/layouts/active
+  GET    /api/stores/{store_id}/layouts
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.roles import OrgRole
+from app.models.user import User
+from testsv2.factories import (
+    create_layout_version,
+    create_membership,
+    create_org,
+    create_store,
+)
+from testsv2.functional.conftest import AUTH_HEADER
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _org_headers(org_id) -> dict:
+    """Return auth + X-Org-Id headers for the given org."""
+    return {**AUTH_HEADER, "X-Org-Id": str(org_id)}
+
+
+# ── POST /api/stores/{store_id}/layouts ───────────────────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_create_layout_version_returns_201(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Owner can create a layout version; response is 201 with correct payload."""
+    org = await create_org(db)
+    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    store = await create_store(db, org_id=org.id)
+
+    response = await client.post(
+        f"/api/stores/{store.id}/layouts",
+        json={"rows": 10, "cols": 8},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["rows"] == 10
+    assert body["cols"] == 8
+    assert body["version_number"] == 1
+    assert body["is_active"] is False
+    assert body["store_id"] == str(store.id)
+    assert body["zones"] == []
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_create_layout_version_increments_version_number(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Second version gets version_number 2."""
+    org = await create_org(db)
+    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    store = await create_store(db, org_id=org.id)
+
+    await client.post(
+        f"/api/stores/{store.id}/layouts",
+        json={"rows": 5, "cols": 5},
+        headers=_org_headers(org.id),
+    )
+    response = await client.post(
+        f"/api/stores/{store.id}/layouts",
+        json={"rows": 6, "cols": 6},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 201
+    assert response.json()["version_number"] == 2
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_create_layout_version_rejects_rows_below_minimum(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """rows < 2 returns 422 Unprocessable Entity."""
+    org = await create_org(db)
+    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    store = await create_store(db, org_id=org.id)
+
+    response = await client.post(
+        f"/api/stores/{store.id}/layouts",
+        json={"rows": 1, "cols": 5},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_create_layout_version_rejects_cols_above_maximum(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """cols > 30 returns 422 Unprocessable Entity."""
+    org = await create_org(db)
+    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    store = await create_store(db, org_id=org.id)
+
+    response = await client.post(
+        f"/api/stores/{store.id}/layouts",
+        json={"rows": 5, "cols": 31},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_create_layout_version_forbidden_for_viewer(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Viewer role cannot create a layout version; returns 403."""
+    org = await create_org(db)
+    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.VIEWER)
+    store = await create_store(db, org_id=org.id)
+
+    response = await client.post(
+        f"/api/stores/{store.id}/layouts",
+        json={"rows": 5, "cols": 5},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 403
+
+
+# ── POST /api/stores/{store_id}/layouts/{id}/activate ─────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_activate_sets_version_active_and_deactivates_others(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Activating one version deactivates all others for the same store."""
+    org = await create_org(db)
+    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    store = await create_store(db, org_id=org.id)
+    v1 = await create_layout_version(db, store_id=store.id, version_number=1, is_active=True)
+    v2 = await create_layout_version(db, store_id=store.id, version_number=2, is_active=False)
+
+    response = await client.post(
+        f"/api/stores/{store.id}/layouts/{v2.id}/activate",
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == str(v2.id)
+    assert body["is_active"] is True
+
+    # Confirm v1 is now inactive via the list endpoint
+    list_response = await client.get(
+        f"/api/stores/{store.id}/layouts",
+        headers=_org_headers(org.id),
+    )
+    versions = {v["id"]: v for v in list_response.json()}
+    assert versions[str(v1.id)]["is_active"] is False
+    assert versions[str(v2.id)]["is_active"] is True
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_activate_unknown_layout_returns_404(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Activating a non-existent layout version returns 404."""
+    import uuid
+
+    org = await create_org(db)
+    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    store = await create_store(db, org_id=org.id)
+
+    response = await client.post(
+        f"/api/stores/{store.id}/layouts/{uuid.uuid4()}/activate",
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 404
+
+
+# ── GET /api/stores/{store_id}/layouts/active ─────────────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_get_active_layout_returns_active_version(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Returns the active layout version with an empty zones list."""
+    org = await create_org(db)
+    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE)
+    store = await create_store(db, org_id=org.id)
+    active = await create_layout_version(
+        db, store_id=store.id, version_number=1, rows=4, cols=6, is_active=True
+    )
+
+    response = await client.get(
+        f"/api/stores/{store.id}/layouts/active",
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == str(active.id)
+    assert body["is_active"] is True
+    assert body["rows"] == 4
+    assert body["cols"] == 6
+    assert body["zones"] == []
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_get_active_layout_returns_404_when_none_active(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Returns 404 when no layout version is active for the store."""
+    org = await create_org(db)
+    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE)
+    store = await create_store(db, org_id=org.id)
+    # Create an inactive version only
+    await create_layout_version(db, store_id=store.id, version_number=1, is_active=False)
+
+    response = await client.get(
+        f"/api/stores/{store.id}/layouts/active",
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 404
+
+
+# ── GET /api/stores/{store_id}/layouts ────────────────────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_list_layout_versions_ordered_by_version_number(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Returns all versions ordered ascending by version_number."""
+    org = await create_org(db)
+    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE)
+    store = await create_store(db, org_id=org.id)
+    # Insert out of order to verify sorting
+    await create_layout_version(db, store_id=store.id, version_number=3)
+    await create_layout_version(db, store_id=store.id, version_number=1)
+    await create_layout_version(db, store_id=store.id, version_number=2)
+
+    response = await client.get(
+        f"/api/stores/{store.id}/layouts",
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    numbers = [v["version_number"] for v in response.json()]
+    assert numbers == [1, 2, 3]
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_list_layout_versions_empty(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Returns an empty list when the store has no layout versions."""
+    org = await create_org(db)
+    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE)
+    store = await create_store(db, org_id=org.id)
+
+    response = await client.get(
+        f"/api/stores/{store.id}/layouts",
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_list_layout_versions_scoped_to_store(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Versions from other stores are not included."""
+    org = await create_org(db)
+    await create_membership(db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER)
+    store_a = await create_store(db, org_id=org.id, name="Store A")
+    store_b = await create_store(db, org_id=org.id, name="Store B")
+    target = await create_layout_version(db, store_id=store_a.id, version_number=1)
+    await create_layout_version(db, store_id=store_b.id, version_number=1)
+
+    response = await client.get(
+        f"/api/stores/{store_a.id}/layouts",
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    ids = [v["id"] for v in response.json()]
+    assert ids == [str(target.id)]


### PR DESCRIPTION
## What
Implements the `LayoutVersion` model with full CRUD operations scoped to a store:

- `POST /api/stores/{store_id}/layouts` — creates a new version with an auto-incremented `version_number` (starting at 1)
- `POST /api/stores/{store_id}/layouts/{id}/activate` — activates one version and deactivates all others for that store
- `GET /api/stores/{store_id}/layouts/active` — returns the currently active version (zones eagerly loaded once BE-07 lands)
- `GET /api/stores/{store_id}/layouts` — returns all versions ordered by `version_number`

Grid dimensions (`rows`, `cols`) are validated at the schema layer: minimum 2, maximum 30. Write endpoints require `ORG_OWNER` or `ORG_ADMIN`. Read endpoints are open to all org members.

## Why
Closes BE-06. Provides the foundation for store layout management. BE-07 (Zone CRUD) and BE-08 (Fixture CRUD) depend on this model and these endpoints.

## How to test
```bash
# Apply the migration
make migrate

# Run the test suite
make test-v2

# Or exercise manually via Swagger
# POST /api/stores/{store_id}/layouts  {"rows": 10, "cols": 8}
# POST /api/stores/{store_id}/layouts/{id}/activate
# GET  /api/stores/{store_id}/layouts/active
# GET  /api/stores/{store_id}/layouts
```

## Checklist
- [x] `make test` passes
- [x] `make lint` passes (black + mypy)
- [x] No hardcoded secrets or credentials
- [x] No new env vars required
- [x] README updated if needed

## Notes
- `LayoutVersion.zones` relationship and `selectinload` in `get_active_layout` are deferred to BE-07 — `TODO(BE-07)` markers are in place in layout_version.py and service.py
- The `GET /active` route is declared before `/{layout_id}` in the router to avoid FastAPI path conflict