### PR TITLE
feat: Zone CRUD within layout versions

### DIFF
--- a/alembic/versions/e2f3a4b5c6d7_add_zones.py
+++ b/alembic/versions/e2f3a4b5c6d7_add_zones.py
@@ -1,0 +1,60 @@
+"""Add zones table.
+
+Revision ID: e2f3a4b5c6d7
+Revises: d1e2f3a4b5c6
+Create Date: 2026-03-31 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers
+revision = "e2f3a4b5c6d7"
+down_revision = "d1e2f3a4b5c6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "zones",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "layout_version_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("color", sa.String(7), nullable=False),
+        sa.Column("cells", sa.JSON(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["layout_version_id"],
+            ["layout_versions.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_zones_layout_version_id", "zones", ["layout_version_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_zones_layout_version_id", table_name="zones")
+    op.drop_table("zones")

--- a/app/layouts/deps.py
+++ b/app/layouts/deps.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import Depends, Path
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.exceptions import NotFound
+from app.models.layout_version import LayoutVersion
+from app.models.store import Store
+from app.stores.deps import get_store_from_path
+
+
+async def get_layout_from_path(
+    layout_version_id: uuid.UUID = Path(..., description="Layout version ID"),
+    store: Store = Depends(get_store_from_path),
+    db: AsyncSession = Depends(get_db),
+) -> LayoutVersion:
+    """
+    Extract ``layout_version_id`` from the path and validate it belongs to the store.
+
+    Raises 404 if the layout version does not exist or belongs to a different store.
+    """
+    result = await db.execute(
+        select(LayoutVersion).where(
+            LayoutVersion.id == layout_version_id,
+            LayoutVersion.store_id == store.id,
+        )
+    )
+    layout = result.scalar_one_or_none()
+    if layout is None:
+        raise NotFound(
+            f"Layout version {layout_version_id} not found for store {store.id}"
+        )
+    return layout

--- a/app/layouts/schemas.py
+++ b/app/layouts/schemas.py
@@ -33,4 +33,3 @@ class LayoutVersionRead(BaseModel):
     zones: list[ZoneRead] = Field(default_factory=list)
     # fixtures populated in BE-08
     fixtures: list = Field(default_factory=list)
-

--- a/app/layouts/schemas.py
+++ b/app/layouts/schemas.py
@@ -7,6 +7,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from app.zones.schemas import ZoneRead
+
 
 class LayoutVersionCreate(BaseModel):
     """Payload for creating a new layout version."""
@@ -28,6 +30,7 @@ class LayoutVersionRead(BaseModel):
     is_active: bool
     created_at: datetime
     updated_at: datetime
-    # Relationship stubs — populated in BE-07 (zones) and BE-08 (fixtures)
-    zones: list = []
-    fixtures: list = []
+    zones: list[ZoneRead] = Field(default_factory=list)
+    # fixtures populated in BE-08
+    fixtures: list = Field(default_factory=list)
+

--- a/app/layouts/service.py
+++ b/app/layouts/service.py
@@ -6,6 +6,7 @@ import uuid
 
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.core.exceptions import NotFound
 from app.models.layout_version import LayoutVersion
@@ -78,11 +79,13 @@ async def get_active_layout(
     store_id: uuid.UUID,
 ) -> LayoutVersion:
     """Return the currently active layout version for the store."""
-    # TODO(BE-07): add .options(selectinload(LayoutVersion.zones)) once the Zone
-    #              model and relationship are introduced in the zones-cellset PR.
-    stmt = select(LayoutVersion).where(
-        LayoutVersion.store_id == store_id,
-        LayoutVersion.is_active == True,  # noqa: E712
+    stmt = (
+        select(LayoutVersion)
+        .where(
+            LayoutVersion.store_id == store_id,
+            LayoutVersion.is_active == True,  # noqa: E712
+        )
+        .options(selectinload(LayoutVersion.zones))
     )
     result = await db.execute(stmt)
     layout = result.scalar_one_or_none()

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from app.admin.routes_users import router as admin_users_router
 from app.health.routes import router as health_router
 from app.layouts.routes import router as layouts_router
 from app.products.routes import router as products_router
+from app.zones.routes import router as zones_router
 from app.stores.routes import router as stores_router
 from app.suppliers.routes import router as suppliers_router
 
@@ -85,6 +86,7 @@ def create_app() -> FastAPI:
     app.include_router(products_router)
     app.include_router(stores_router)
     app.include_router(layouts_router)
+    app.include_router(zones_router)
 
     return app
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,6 +7,7 @@ from app.models.product import Product
 from app.models.product_supplier import ProductSupplier
 from app.models.store import Store
 from app.models.layout_version import LayoutVersion
+from app.models.zone import Zone
 
 __all__ = [
     "BaseModel",
@@ -18,4 +19,5 @@ __all__ = [
     "ProductSupplier",
     "Store",
     "LayoutVersion",
+    "Zone",
 ]

--- a/app/models/layout_version.py
+++ b/app/models/layout_version.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import BaseModel
+
+if TYPE_CHECKING:
+    from app.models.zone import Zone
 
 
 class LayoutVersion(BaseModel):
@@ -40,5 +44,11 @@ class LayoutVersion(BaseModel):
         onupdate=func.now(),
         nullable=False,
     )
-    # TODO(BE-07): add `zones` relationship once Zone model is defined in the
-    #              zones-cellset PR (back_populates="layout_version", lazy="selectin").
+
+    # Populated in BE-07 — selectin-loaded so zones are always available on read
+    zones: Mapped[list["Zone"]] = relationship(
+        "Zone",
+        back_populates="layout_version",
+        lazy="selectin",
+        cascade="all, delete-orphan",
+    )

--- a/app/models/zone.py
+++ b/app/models/zone.py
@@ -1,0 +1,48 @@
+"""Zone model — a named, coloured cell-set within a layout version grid."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, JSON, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import BaseModel
+
+if TYPE_CHECKING:
+    from app.models.layout_version import LayoutVersion
+
+
+class Zone(BaseModel):
+    """
+    Represents a named area within a layout version, defined by an arbitrary
+    set of grid cells stored as JSON: [{"row": 0, "col": 0}, ...].
+    """
+
+    __tablename__ = "zones"
+
+    layout_version_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("layout_versions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    # Hex colour code, e.g. "#FF5733"
+    color: Mapped[str] = mapped_column(String(7), nullable=False)
+    # Cell positions: [{"row": int, "col": int}, ...]
+    cells: Mapped[list] = mapped_column(JSON, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    layout_version: Mapped["LayoutVersion"] = relationship(
+        "LayoutVersion",
+        back_populates="zones",
+    )

--- a/app/zones/__init__.py
+++ b/app/zones/__init__.py
@@ -1,0 +1,1 @@
+"""Zones package."""

--- a/app/zones/routes.py
+++ b/app/zones/routes.py
@@ -11,6 +11,7 @@ from app.core.database import get_db
 from app.core.roles import OrgRole
 from app.layouts.deps import get_layout_from_path
 from app.models.layout_version import LayoutVersion
+from app.models.zone import Zone
 from app.orgs.deps import RequireOrgRole
 from app.zones.schemas import ZoneCreate, ZoneRead, ZoneUpdate
 from app.zones import service
@@ -27,10 +28,10 @@ router = APIRouter(
 async def list_zones(
     db: AsyncSession = Depends(get_db),
     layout: LayoutVersion = Depends(get_layout_from_path),
-) -> list[ZoneRead]:
+) -> list[Zone]:
     """Return all zones for the layout version ordered by creation date."""
     zones = await service.list_zones(db, layout.id)
-    return [ZoneRead.model_validate(z) for z in zones]
+    return zones
 
 
 @router.get("/{zone_id}", response_model=ZoneRead)
@@ -38,10 +39,10 @@ async def get_zone(
     zone_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
     layout: LayoutVersion = Depends(get_layout_from_path),
-) -> ZoneRead:
+) -> Zone:
     """Return a single zone by ID."""
     zone = await service.get_zone(db, zone_id, layout.id)
-    return ZoneRead.model_validate(zone)
+    return zone
 
 
 # ── Write endpoints (OWNER or ADMIN only) ─────────────────────────────────────
@@ -53,14 +54,14 @@ async def create_zone(
     db: AsyncSession = Depends(get_db),
     layout: LayoutVersion = Depends(get_layout_from_path),
     _: object = Depends(RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)),
-) -> ZoneRead:
+) -> Zone:
     """
     Create a new zone within a layout version.
 
     All cells must lie within the layout grid and must not overlap existing zones.
     """
     zone = await service.create_zone(db, layout.id, data)
-    return ZoneRead.model_validate(zone)
+    return zone
 
 
 @router.put("/{zone_id}", response_model=ZoneRead)
@@ -70,10 +71,10 @@ async def update_zone(
     db: AsyncSession = Depends(get_db),
     layout: LayoutVersion = Depends(get_layout_from_path),
     _: object = Depends(RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)),
-) -> ZoneRead:
+) -> Zone:
     """Partially update a zone's name, color, and/or cells."""
     zone = await service.update_zone(db, zone_id, layout.id, data)
-    return ZoneRead.model_validate(zone)
+    return zone
 
 
 @router.delete("/{zone_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/app/zones/routes.py
+++ b/app/zones/routes.py
@@ -1,0 +1,87 @@
+"""Routes for Zone CRUD operations."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.roles import OrgRole
+from app.layouts.deps import get_layout_from_path
+from app.models.layout_version import LayoutVersion
+from app.orgs.deps import RequireOrgRole
+from app.zones.schemas import ZoneCreate, ZoneRead, ZoneUpdate
+from app.zones import service
+
+router = APIRouter(
+    prefix="/api/stores/{store_id}/layouts/{layout_version_id}/zones",
+    tags=["zones"],
+)
+
+# ── Read endpoints (all org members) ──────────────────────────────────────────
+
+
+@router.get("", response_model=list[ZoneRead])
+async def list_zones(
+    db: AsyncSession = Depends(get_db),
+    layout: LayoutVersion = Depends(get_layout_from_path),
+) -> list[ZoneRead]:
+    """Return all zones for the layout version ordered by creation date."""
+    zones = await service.list_zones(db, layout.id)
+    return [ZoneRead.model_validate(z) for z in zones]
+
+
+@router.get("/{zone_id}", response_model=ZoneRead)
+async def get_zone(
+    zone_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    layout: LayoutVersion = Depends(get_layout_from_path),
+) -> ZoneRead:
+    """Return a single zone by ID."""
+    zone = await service.get_zone(db, zone_id, layout.id)
+    return ZoneRead.model_validate(zone)
+
+
+# ── Write endpoints (OWNER or ADMIN only) ─────────────────────────────────────
+
+
+@router.post("", response_model=ZoneRead, status_code=status.HTTP_201_CREATED)
+async def create_zone(
+    data: ZoneCreate,
+    db: AsyncSession = Depends(get_db),
+    layout: LayoutVersion = Depends(get_layout_from_path),
+    _: object = Depends(RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)),
+) -> ZoneRead:
+    """
+    Create a new zone within a layout version.
+
+    All cells must lie within the layout grid and must not overlap existing zones.
+    """
+    zone = await service.create_zone(db, layout.id, data)
+    return ZoneRead.model_validate(zone)
+
+
+@router.put("/{zone_id}", response_model=ZoneRead)
+async def update_zone(
+    zone_id: uuid.UUID,
+    data: ZoneUpdate,
+    db: AsyncSession = Depends(get_db),
+    layout: LayoutVersion = Depends(get_layout_from_path),
+    _: object = Depends(RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)),
+) -> ZoneRead:
+    """Partially update a zone's name, color, and/or cells."""
+    zone = await service.update_zone(db, zone_id, layout.id, data)
+    return ZoneRead.model_validate(zone)
+
+
+@router.delete("/{zone_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_zone(
+    zone_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    layout: LayoutVersion = Depends(get_layout_from_path),
+    _: object = Depends(RequireOrgRole(OrgRole.OWNER, OrgRole.ADMIN)),
+) -> None:
+    """Delete a zone by ID."""
+    await service.delete_zone(db, zone_id, layout.id)

--- a/app/zones/schemas.py
+++ b/app/zones/schemas.py
@@ -1,0 +1,74 @@
+"""Pydantic schemas for Zone."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class CellPosition(BaseModel):
+    """A single grid cell identified by its zero-based row and column indices."""
+
+    row: int = Field(..., ge=0, description="Zero-based row index")
+    col: int = Field(..., ge=0, description="Zero-based column index")
+
+
+class ZoneCreate(BaseModel):
+    """Payload for creating a new zone."""
+
+    name: str = Field(..., min_length=1, max_length=100)
+    color: str = Field(
+        ..., pattern=r"^#[0-9A-Fa-f]{6}$", description="Hex colour, e.g. #FF5733"
+    )
+    cells: list[CellPosition] = Field(..., min_length=1, description="At least 1 cell required")
+
+    @field_validator("cells")
+    @classmethod
+    def no_duplicate_cells(cls, v: list[CellPosition]) -> list[CellPosition]:
+        """Reject duplicate (row, col) pairs within a single zone."""
+        seen: set[tuple[int, int]] = set()
+        for cell in v:
+            key = (cell.row, cell.col)
+            if key in seen:
+                raise ValueError(f"Duplicate cell ({cell.row}, {cell.col}) in zone")
+            seen.add(key)
+        return v
+
+
+class ZoneUpdate(BaseModel):
+    """Payload for partially updating a zone. All fields are optional."""
+
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    color: Optional[str] = Field(None, pattern=r"^#[0-9A-Fa-f]{6}$")
+    cells: Optional[list[CellPosition]] = Field(None, min_length=1)
+
+    @field_validator("cells")
+    @classmethod
+    def no_duplicate_cells(cls, v: Optional[list[CellPosition]]) -> Optional[list[CellPosition]]:
+        """Reject duplicate (row, col) pairs within a single zone."""
+        if v is None:
+            return v
+        seen: set[tuple[int, int]] = set()
+        for cell in v:
+            key = (cell.row, cell.col)
+            if key in seen:
+                raise ValueError(f"Duplicate cell ({cell.row}, {cell.col}) in zone")
+            seen.add(key)
+        return v
+
+
+class ZoneRead(BaseModel):
+    """Full representation of a zone returned from the API."""
+
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    layout_version_id: uuid.UUID
+    name: str
+    color: str
+    cells: list[CellPosition]
+    created_at: datetime
+    updated_at: datetime

--- a/app/zones/schemas.py
+++ b/app/zones/schemas.py
@@ -23,7 +23,9 @@ class ZoneCreate(BaseModel):
     color: str = Field(
         ..., pattern=r"^#[0-9A-Fa-f]{6}$", description="Hex colour, e.g. #FF5733"
     )
-    cells: list[CellPosition] = Field(..., min_length=1, description="At least 1 cell required")
+    cells: list[CellPosition] = Field(
+        ..., min_length=1, description="At least 1 cell required"
+    )
 
     @field_validator("cells")
     @classmethod
@@ -47,7 +49,9 @@ class ZoneUpdate(BaseModel):
 
     @field_validator("cells")
     @classmethod
-    def no_duplicate_cells(cls, v: Optional[list[CellPosition]]) -> Optional[list[CellPosition]]:
+    def no_duplicate_cells(
+        cls, v: Optional[list[CellPosition]]
+    ) -> Optional[list[CellPosition]]:
         """Reject duplicate (row, col) pairs within a single zone."""
         if v is None:
             return v

--- a/app/zones/service.py
+++ b/app/zones/service.py
@@ -13,7 +13,6 @@ from app.models.layout_version import LayoutVersion
 from app.models.zone import Zone
 from app.zones.schemas import ZoneCreate, ZoneUpdate
 
-
 # ── Internal helpers ──────────────────────────────────────────────────────────
 
 
@@ -117,7 +116,9 @@ async def get_zone(
     )
     zone = result.scalar_one_or_none()
     if zone is None:
-        raise NotFound(f"Zone {zone_id} not found in layout version {layout_version_id}")
+        raise NotFound(
+            f"Zone {zone_id} not found in layout version {layout_version_id}"
+        )
     return zone
 
 

--- a/app/zones/service.py
+++ b/app/zones/service.py
@@ -46,7 +46,7 @@ async def _check_zone_overlap(
     exclude_zone_id: Optional[uuid.UUID] = None,
 ) -> None:
     """
-    Raise AlreadyExists(409) if the given cells overlap with any existing zone
+    Raise AppError(status_code=409) if the given cells overlap with any existing zone
     in the layout (excluding the zone being updated, if provided).
     """
     stmt = select(Zone).where(Zone.layout_version_id == layout_version_id)
@@ -130,7 +130,7 @@ async def list_zones(
     result = await db.execute(
         select(Zone)
         .where(Zone.layout_version_id == layout_version_id)
-        .order_by(Zone.created_at.asc())
+        .order_by(Zone.created_at.asc(), Zone.id.asc())
     )
     return list(result.scalars().all())
 

--- a/app/zones/service.py
+++ b/app/zones/service.py
@@ -1,0 +1,177 @@
+"""Service layer for Zone CRUD operations."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import AppError, NotFound
+from app.models.layout_version import LayoutVersion
+from app.models.zone import Zone
+from app.zones.schemas import ZoneCreate, ZoneUpdate
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+
+async def _get_layout(db: AsyncSession, layout_version_id: uuid.UUID) -> LayoutVersion:
+    """Load a LayoutVersion by ID; raises NotFound if missing."""
+    result = await db.execute(
+        select(LayoutVersion).where(LayoutVersion.id == layout_version_id)
+    )
+    layout = result.scalar_one_or_none()
+    if layout is None:
+        raise NotFound(f"Layout version {layout_version_id} not found")
+    return layout
+
+
+def _check_bounds(layout: LayoutVersion, cells: list[dict]) -> None:
+    """Raise AppError(400) if any cell falls outside the layout grid dimensions."""
+    for cell in cells:
+        row, col = cell["row"], cell["col"]
+        if row < 0 or row >= layout.rows or col < 0 or col >= layout.cols:
+            raise AppError(
+                f"Cell ({row}, {col}) is outside the layout bounds "
+                f"({layout.rows} rows × {layout.cols} cols)",
+                status_code=400,
+            )
+
+
+async def _check_zone_overlap(
+    db: AsyncSession,
+    layout_version_id: uuid.UUID,
+    cells: list[dict],
+    exclude_zone_id: Optional[uuid.UUID] = None,
+) -> None:
+    """
+    Raise AlreadyExists(409) if the given cells overlap with any existing zone
+    in the layout (excluding the zone being updated, if provided).
+    """
+    stmt = select(Zone).where(Zone.layout_version_id == layout_version_id)
+    result = await db.execute(stmt)
+    existing_zones = result.scalars().all()
+
+    requested: set[tuple[int, int]] = {(c["row"], c["col"]) for c in cells}
+    for zone in existing_zones:
+        if exclude_zone_id and zone.id == exclude_zone_id:
+            continue
+        zone_cells: set[tuple[int, int]] = {(c["row"], c["col"]) for c in zone.cells}
+        overlap = requested & zone_cells
+        if overlap:
+            raise AppError(
+                f"Cells {sorted(overlap)} overlap with existing zone '{zone.name}'",
+                status_code=409,
+            )
+
+    # TODO(BE-08): also check overlap against fixtures once the Fixture model exists.
+
+
+# ── Public service functions ──────────────────────────────────────────────────
+
+
+async def create_zone(
+    db: AsyncSession,
+    layout_version_id: uuid.UUID,
+    data: ZoneCreate,
+) -> Zone:
+    """
+    Create a new zone within a layout version.
+
+    Validates:
+    - All cells are within grid bounds (400 if not)
+    - No cells overlap with existing zones or fixtures (409 if they do)
+    - At least 1 cell / no duplicates (validated by schema)
+    """
+    layout = await _get_layout(db, layout_version_id)
+    cells = [{"row": c.row, "col": c.col} for c in data.cells]
+
+    _check_bounds(layout, cells)
+    await _check_zone_overlap(db, layout_version_id, cells)
+
+    zone = Zone(
+        layout_version_id=layout_version_id,
+        name=data.name,
+        color=data.color,
+        cells=cells,
+    )
+    db.add(zone)
+    await db.flush()
+    await db.refresh(zone)
+    return zone
+
+
+async def get_zone(
+    db: AsyncSession,
+    zone_id: uuid.UUID,
+    layout_version_id: uuid.UUID,
+) -> Zone:
+    """Return a zone by ID, scoped to layout_version_id; raises NotFound if missing."""
+    result = await db.execute(
+        select(Zone).where(
+            Zone.id == zone_id,
+            Zone.layout_version_id == layout_version_id,
+        )
+    )
+    zone = result.scalar_one_or_none()
+    if zone is None:
+        raise NotFound(f"Zone {zone_id} not found in layout version {layout_version_id}")
+    return zone
+
+
+async def list_zones(
+    db: AsyncSession,
+    layout_version_id: uuid.UUID,
+) -> list[Zone]:
+    """Return all zones for a layout version ordered by created_at."""
+    result = await db.execute(
+        select(Zone)
+        .where(Zone.layout_version_id == layout_version_id)
+        .order_by(Zone.created_at.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def update_zone(
+    db: AsyncSession,
+    zone_id: uuid.UUID,
+    layout_version_id: uuid.UUID,
+    data: ZoneUpdate,
+) -> Zone:
+    """
+    Partially update a zone's name, color, and/or cells.
+
+    If cells are updated, re-runs bounds and overlap validation (excluding
+    the zone itself from the overlap check).
+    """
+    zone = await get_zone(db, zone_id, layout_version_id)
+
+    if data.cells is not None:
+        layout = await _get_layout(db, layout_version_id)
+        cells = [{"row": c.row, "col": c.col} for c in data.cells]
+        _check_bounds(layout, cells)
+        await _check_zone_overlap(db, layout_version_id, cells, exclude_zone_id=zone_id)
+        zone.cells = cells
+
+    if data.name is not None:
+        zone.name = data.name
+
+    if data.color is not None:
+        zone.color = data.color
+
+    await db.flush()
+    await db.refresh(zone)
+    return zone
+
+
+async def delete_zone(
+    db: AsyncSession,
+    zone_id: uuid.UUID,
+    layout_version_id: uuid.UUID,
+) -> None:
+    """Delete a zone; cascade in the DB handles any child records."""
+    zone = await get_zone(db, zone_id, layout_version_id)
+    await db.delete(zone)
+    await db.flush()

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -19,6 +19,7 @@ Complete reference for every endpoint in the EasyInventory API. All routes retur
 - [Product–Supplier Links](#productsupplier-links)
 - [Stores](#stores)
 - [Layout Versions](#layout-versions)
+- [Zones](#zones)
 - [Admin: Organizations](#admin-organizations)
 - [Admin: Users](#admin-users)
 - [Invite Flow Details](#invite-flow-details)
@@ -677,7 +678,7 @@ Creates a new store within the current organization.
 
 ## Layout Versions
 
-Layout versions represent versioned grid configurations for a store. Each version defines a rows × cols grid. Only one version can be active at a time per store. Zones (BE-07) and fixtures (BE-08) are nested within a layout version.
+Layout versions represent versioned grid configurations for a store. Each version defines a rows × cols grid. Only one version can be active at a time per store. Zones and fixtures (BE-08) are nested within a layout version.
 
 **All layout endpoints require a valid `X-Org-Id` header** and validate that `store_id` belongs to the caller's organization.
 
@@ -809,6 +810,156 @@ Activates the specified layout version and deactivates all other versions for th
 - `403` — Caller is not `ORG_OWNER` or `ORG_ADMIN`.
 - `404` — Layout version not found for the store.
 - `404` — Store not found in the current org.
+
+---
+
+## Zones
+
+Zones represent named, coloured regions of a layout version's grid. Each zone owns a set of `(row, col)` cell positions. A cell may belong to at most one zone within a layout version.
+
+All zone endpoints are nested under a store and a layout version:
+`/api/stores/{store_id}/layouts/{layout_version_id}/zones`
+
+They require a valid `X-Org-Id` header and validate that both `store_id` and `layout_version_id` belong to the caller's organization.
+
+---
+
+### `GET /api/stores/{store_id}/layouts/{layout_version_id}/zones`
+
+Returns all zones for the layout version ordered by `created_at` ascending.
+
+**Auth:** Required — any org member  
+**Response** `200`
+
+```json
+[
+  {
+    "id": "zone-uuid",
+    "layout_version_id": "layout-uuid",
+    "name": "Produce",
+    "color": "#00FF00",
+    "cells": [
+      {"row": 0, "col": 0},
+      {"row": 0, "col": 1}
+    ],
+    "created_at": "2026-03-31T10:00:00Z",
+    "updated_at": "2026-03-31T10:00:00Z"
+  }
+]
+```
+
+**Errors:**
+- `404` — Layout version not found for the store.
+- `404` — Store not found in the current org.
+
+---
+
+### `POST /api/stores/{store_id}/layouts/{layout_version_id}/zones`
+
+Creates a new zone within a layout version.
+
+**Auth:** Required — `ORG_OWNER` or `ORG_ADMIN`  
+**Request Body**
+
+```json
+{
+  "name": "Produce",
+  "color": "#00FF00",
+  "cells": [
+    {"row": 0, "col": 0},
+    {"row": 0, "col": 1}
+  ]
+}
+```
+
+| Field | Type | Required | Constraints | Description |
+|---|---|---|---|---|
+| `name` | string | Yes | 1–100 chars | Zone display name |
+| `color` | string | Yes | `#RRGGBB` hex | Zone colour |
+| `cells` | array | Yes | min 1, no duplicates | Cell positions claimed by this zone |
+| `cells[].row` | integer | Yes | ≥ 0, < `layout.rows` | Row index (0-based) |
+| `cells[].col` | integer | Yes | ≥ 0, < `layout.cols` | Column index (0-based) |
+
+**Response** `201`
+
+```json
+{
+  "id": "zone-uuid",
+  "layout_version_id": "layout-uuid",
+  "name": "Produce",
+  "color": "#00FF00",
+  "cells": [
+    {"row": 0, "col": 0},
+    {"row": 0, "col": 1}
+  ],
+  "created_at": "2026-03-31T10:00:00Z",
+  "updated_at": "2026-03-31T10:00:00Z"
+}
+```
+
+**Errors:**
+- `400` — One or more cells lie outside the layout's grid dimensions.
+- `403` — Caller is not `ORG_OWNER` or `ORG_ADMIN`.
+- `404` — Layout version or store not found in the current org.
+- `409` — One or more cells overlap with an existing zone.
+- `422` — `cells` is empty, contains duplicates, or `color` is not a valid `#RRGGBB` hex string.
+
+---
+
+### `GET /api/stores/{store_id}/layouts/{layout_version_id}/zones/{zone_id}`
+
+Returns a single zone by ID.
+
+**Auth:** Required — any org member  
+**Response** `200` — Zone object (same shape as list items)
+
+**Errors:**
+- `404` — Zone, layout version, or store not found in the current org.
+
+---
+
+### `PUT /api/stores/{store_id}/layouts/{layout_version_id}/zones/{zone_id}`
+
+Partially updates a zone. Only the fields provided are changed.
+
+**Auth:** Required — `ORG_OWNER` or `ORG_ADMIN`  
+**Request Body** — all fields optional
+
+```json
+{
+  "name": "Dairy",
+  "color": "#0000FF",
+  "cells": [{"row": 1, "col": 0}]
+}
+```
+
+| Field | Type | Constraints | Description |
+|---|---|---|---|
+| `name` | string | 1–100 chars | New display name |
+| `color` | string | `#RRGGBB` hex | New colour |
+| `cells` | array | min 1, no duplicates, within grid bounds, no overlap (excluding self) | New cell set |
+
+**Response** `200` — Updated zone object
+
+**Errors:**
+- `400` — One or more new cells lie outside the layout's grid dimensions.
+- `403` — Caller is not `ORG_OWNER` or `ORG_ADMIN`.
+- `404` — Zone, layout version, or store not found in the current org.
+- `409` — New cells overlap with another existing zone.
+- `422` — Invalid field values.
+
+---
+
+### `DELETE /api/stores/{store_id}/layouts/{layout_version_id}/zones/{zone_id}`
+
+Deletes a zone.
+
+**Auth:** Required — `ORG_OWNER` or `ORG_ADMIN`  
+**Response** `204` — No content
+
+**Errors:**
+- `403` — Caller is not `ORG_OWNER` or `ORG_ADMIN`.
+- `404` — Zone, layout version, or store not found in the current org.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,9 +68,15 @@ easyinventory-api/
 │   │   └── service.py           #   Store data access
 │   │
 │   ├── layouts/                 # Layout versions domain
+│   │   ├── deps.py              #   get_layout_from_path path dependency
 │   │   ├── routes.py            #   Layout CRUD + activate endpoints (store-scoped)
 │   │   ├── schemas.py           #   LayoutVersionCreate / LayoutVersionRead schemas
 │   │   └── service.py           #   Layout data access (create, activate, list, get active)
+│   │
+│   ├── zones/                   # Zones domain (nested within layout versions)
+│   │   ├── routes.py            #   Zone CRUD endpoints (layout-version-scoped)
+│   │   ├── schemas.py           #   ZoneCreate / ZoneUpdate / ZoneRead schemas
+│   │   └── service.py           #   Zone data access (create, list, get, update, delete)
 │   │
 │   ├── suppliers/               # Suppliers domain
 │   │   ├── routes.py            #   Supplier CRUD endpoints
@@ -99,7 +105,8 @@ easyinventory-api/
 │       ├── product.py           #   Product (org-scoped, SKU, category)
 │       ├── product_supplier.py  #   ProductSupplier join table (is_active flag)
 │       ├── store.py             #   Store (org-scoped, is_active, updated_at)
-│       └── layout_version.py    #   LayoutVersion (store-scoped, version_number, rows, cols, is_active)
+│       ├── layout_version.py    #   LayoutVersion (store-scoped, version_number, rows, cols, is_active)
+│       └── zone.py              #   Zone (layout-version-scoped, name, color, cells JSON)
 │
 ├── alembic/                     # Database migration infrastructure
 │   ├── env.py                   #   Async migration runner (reads DATABASE_URL)
@@ -466,7 +473,8 @@ All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which
 | `Product` | `products` | `org_id` (FK), `name`, `description`, `sku`, `category` | → `ProductSupplier` (one-to-many) |
 | `ProductSupplier` | `product_suppliers` | `product_id` (FK), `supplier_id` (FK), `is_active` | → `Supplier` / Unique on `(product_id, supplier_id)` |
 | `Store` | `stores` | `org_id` (FK, CASCADE), `name`, `is_active`, `updated_at` | → `LayoutVersion` (one-to-many) |
-| `LayoutVersion` | `layout_versions` | `store_id` (FK, CASCADE), `version_number`, `rows`, `cols`, `is_active`, `updated_at` | Unique on `(store_id, version_number)` |
+| `LayoutVersion` | `layout_versions` | `store_id` (FK, CASCADE), `version_number`, `rows`, `cols`, `is_active`, `updated_at` | → `Zone` (one-to-many); unique on `(store_id, version_number)` |
+| `Zone` | `zones` | `layout_version_id` (FK, CASCADE), `name`, `color`, `cells` (JSON), `updated_at` | → `LayoutVersion` |
 
 ### Key design decisions
 
@@ -477,6 +485,7 @@ All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which
 - **Join table with metadata** — `ProductSupplier` is not just a simple many-to-many join. It has an `is_active` flag, allowing you to deactivate a specific product-supplier relationship without removing it.
 - **Cascade deletes** — `Store.org_id` is defined with `ondelete="CASCADE"`, so all stores are deleted automatically when their parent organization is deleted.
 - **Layout versioning** — `LayoutVersion` models a point-in-time grid configuration for a store. Versions are immutable once created (grid dimensions cannot be changed), and only one may be `is_active=True` at a time. The `activate` endpoint uses a bulk `UPDATE … SET is_active=False` across the store, then a targeted `UPDATE … SET is_active=True` on the target, making activation atomic within the transaction.
+- **Zone cell storage** — A zone's claimed cells are stored as a JSON array of `{"row": int, "col": int}` objects rather than a normalised join table. This avoids a third table for what is effectively a small, denormalised blob that is always read and written as a unit. Cell-level validation (bounds check, intra-request duplicate check, cross-zone overlap detection) happens in the service layer before the row is written.
 
 ---
 

--- a/testsv2/factories.py
+++ b/testsv2/factories.py
@@ -19,6 +19,7 @@ from app.models.product_supplier import ProductSupplier
 from app.models.store import Store
 from app.models.supplier import Supplier
 from app.models.user import User
+from app.models.zone import Zone
 
 
 async def create_user(
@@ -197,3 +198,23 @@ async def create_layout_version(
     db.add(layout)
     await db.flush()
     return layout
+
+
+async def create_zone(
+    db: AsyncSession,
+    *,
+    layout_version_id: uuid.UUID,
+    name: str = "Zone A",
+    color: str = "#FF0000",
+    cells: list[dict] | None = None,
+) -> Zone:
+    """Insert a ``Zone`` row and return it."""
+    zone = Zone(
+        layout_version_id=layout_version_id,
+        name=name,
+        color=color,
+        cells=cells or [{"row": 0, "col": 0}],
+    )
+    db.add(zone)
+    await db.flush()
+    return zone

--- a/testsv2/factories.py
+++ b/testsv2/factories.py
@@ -213,7 +213,7 @@ async def create_zone(
         layout_version_id=layout_version_id,
         name=name,
         color=color,
-        cells=cells or [{"row": 0, "col": 0}],
+        cells=cells if cells is not None else [{"row": 0, "col": 0}],
     )
     db.add(zone)
     await db.flush()

--- a/testsv2/functional/test_zone_endpoints.py
+++ b/testsv2/functional/test_zone_endpoints.py
@@ -1,0 +1,565 @@
+"""
+Functional tests for the zone routes.
+
+  POST   /api/stores/{store_id}/layouts/{layout_version_id}/zones
+  GET    /api/stores/{store_id}/layouts/{layout_version_id}/zones
+  GET    /api/stores/{store_id}/layouts/{layout_version_id}/zones/{zone_id}
+  PUT    /api/stores/{store_id}/layouts/{layout_version_id}/zones/{zone_id}
+  DELETE /api/stores/{store_id}/layouts/{layout_version_id}/zones/{zone_id}
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.roles import OrgRole
+from app.models.user import User
+from testsv2.factories import (
+    create_layout_version,
+    create_membership,
+    create_org,
+    create_store,
+    create_zone,
+)
+from testsv2.functional.conftest import AUTH_HEADER
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _org_headers(org_id) -> dict:
+    return {**AUTH_HEADER, "X-Org-Id": str(org_id)}
+
+
+def _zones_url(store_id, layout_version_id) -> str:
+    return f"/api/stores/{store_id}/layouts/{layout_version_id}/zones"
+
+
+def _zone_url(store_id, layout_version_id, zone_id) -> str:
+    return f"/api/stores/{store_id}/layouts/{layout_version_id}/zones/{zone_id}"
+
+
+# ── POST – create zone ────────────────────────────────────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_create_zone_returns_201(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Owner can create a zone; response is 201 with correct payload."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+
+    response = await client.post(
+        _zones_url(store.id, layout.id),
+        json={"name": "Zone A", "color": "#FF0000", "cells": [{"row": 0, "col": 0}]},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["name"] == "Zone A"
+    assert body["color"] == "#FF0000"
+    assert body["cells"] == [{"row": 0, "col": 0}]
+    assert body["layout_version_id"] == str(layout.id)
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_create_zone_rejects_cell_outside_grid_bounds(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """A cell outside the grid dimensions returns 400."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=3, cols=3, version_number=1
+    )
+
+    response = await client.post(
+        _zones_url(store.id, layout.id),
+        json={"name": "OOB Zone", "color": "#0000FF", "cells": [{"row": 3, "col": 0}]},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_create_zone_rejects_cell_col_outside_bounds(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """A cell with col >= layout.cols returns 400."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=3, cols=3, version_number=1
+    )
+
+    response = await client.post(
+        _zones_url(store.id, layout.id),
+        json={"name": "OOB Zone", "color": "#0000FF", "cells": [{"row": 0, "col": 3}]},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_create_zone_rejects_overlapping_cells(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Creating a zone with cells occupied by another zone returns 409."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+    await create_zone(
+        db,
+        layout_version_id=layout.id,
+        name="Zone A",
+        color="#FF0000",
+        cells=[{"row": 0, "col": 0}, {"row": 0, "col": 1}],
+    )
+
+    response = await client.post(
+        _zones_url(store.id, layout.id),
+        json={
+            "name": "Zone B",
+            "color": "#00FF00",
+            "cells": [{"row": 0, "col": 0}],
+        },
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 409
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_create_zone_rejects_duplicate_cells_in_request(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Providing duplicate cells within the same request body returns 422."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+
+    response = await client.post(
+        _zones_url(store.id, layout.id),
+        json={
+            "name": "Zone A",
+            "color": "#FF0000",
+            "cells": [{"row": 0, "col": 0}, {"row": 0, "col": 0}],
+        },
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_create_zone_rejects_zero_cells(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Providing an empty cells list returns 422."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+
+    response = await client.post(
+        _zones_url(store.id, layout.id),
+        json={"name": "Zone A", "color": "#FF0000", "cells": []},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_create_zone_viewer_forbidden(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """A user with EMPLOYEE role cannot create zones (403)."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+
+    response = await client.post(
+        _zones_url(store.id, layout.id),
+        json={"name": "Zone A", "color": "#FF0000", "cells": [{"row": 0, "col": 0}]},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 403
+
+
+# ── GET – list zones ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_list_zones_returns_ordered_by_created_at(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """List returns all zones ordered by creation date ascending."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+    await create_zone(
+        db,
+        layout_version_id=layout.id,
+        name="Zone A",
+        color="#FF0000",
+        cells=[{"row": 0, "col": 0}],
+    )
+    await create_zone(
+        db,
+        layout_version_id=layout.id,
+        name="Zone B",
+        color="#00FF00",
+        cells=[{"row": 1, "col": 0}],
+    )
+
+    response = await client.get(
+        _zones_url(store.id, layout.id),
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    names = [z["name"] for z in response.json()]
+    assert names == ["Zone A", "Zone B"]
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_list_zones_empty_returns_empty_list(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """List returns an empty array when no zones exist."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+
+    response = await client.get(
+        _zones_url(store.id, layout.id),
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+# ── GET – single zone ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_get_zone_returns_200(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """GET /{zone_id} returns the zone."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+    zone = await create_zone(
+        db, layout_version_id=layout.id, name="Zone A", color="#FF0000"
+    )
+
+    response = await client.get(
+        _zone_url(store.id, layout.id, zone.id),
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["id"] == str(zone.id)
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_get_zone_returns_404_for_unknown(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """GET with unknown zone_id returns 404."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+
+    response = await client.get(
+        _zone_url(store.id, layout.id, uuid.uuid4()),
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 404
+
+
+# ── PUT – update zone ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_update_zone_name_and_color(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """PUT updates name and color; cells unchanged."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+    zone = await create_zone(
+        db, layout_version_id=layout.id, name="Zone A", color="#FF0000"
+    )
+
+    response = await client.put(
+        _zone_url(store.id, layout.id, zone.id),
+        json={"name": "Updated Zone", "color": "#0000FF"},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "Updated Zone"
+    assert body["color"] == "#0000FF"
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_update_zone_cells(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """PUT updates cells when provided."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+    zone = await create_zone(
+        db,
+        layout_version_id=layout.id,
+        name="Zone A",
+        color="#FF0000",
+        cells=[{"row": 0, "col": 0}],
+    )
+
+    response = await client.put(
+        _zone_url(store.id, layout.id, zone.id),
+        json={"cells": [{"row": 2, "col": 2}, {"row": 2, "col": 3}]},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["cells"] == [{"row": 2, "col": 2}, {"row": 2, "col": 3}]
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_update_zone_cells_overlap_rejected(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Updating cells to overlap another zone returns 409."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+    await create_zone(
+        db,
+        layout_version_id=layout.id,
+        name="Zone A",
+        color="#FF0000",
+        cells=[{"row": 0, "col": 0}],
+    )
+    zone_b = await create_zone(
+        db,
+        layout_version_id=layout.id,
+        name="Zone B",
+        color="#00FF00",
+        cells=[{"row": 1, "col": 0}],
+    )
+
+    response = await client.put(
+        _zone_url(store.id, layout.id, zone_b.id),
+        json={"cells": [{"row": 0, "col": 0}]},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 409
+
+
+# ── DELETE ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_delete_zone_returns_204(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """DELETE returns 204 and the zone is no longer retrievable."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+    zone = await create_zone(
+        db, layout_version_id=layout.id, name="Zone A", color="#FF0000"
+    )
+
+    response = await client.delete(
+        _zone_url(store.id, layout.id, zone.id),
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 204
+
+    # Confirm it is gone
+    get_response = await client.get(
+        _zone_url(store.id, layout.id, zone.id),
+        headers=_org_headers(org.id),
+    )
+    assert get_response.status_code == 404
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_delete_zone_unknown_returns_404(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """DELETE with an unknown zone_id returns 404."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1
+    )
+
+    response = await client.delete(
+        _zone_url(store.id, layout.id, uuid.uuid4()),
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 404
+
+
+# ── Zones appear in GET /layouts/active ───────────────────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_zones_visible_in_active_layout(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Zones created in the active layout are included in GET /active."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    layout = await create_layout_version(
+        db, store_id=store.id, rows=5, cols=5, version_number=1, is_active=True
+    )
+    await create_zone(
+        db,
+        layout_version_id=layout.id,
+        name="Zone A",
+        color="#FF0000",
+        cells=[{"row": 0, "col": 0}],
+    )
+
+    response = await client.get(
+        f"/api/stores/{store.id}/layouts/active",
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["zones"]) == 1
+    assert body["zones"][0]["name"] == "Zone A"


### PR DESCRIPTION
## What

Introduces the `Zone` model and a full CRUD API nested under layout versions. Each zone represents a named, coloured region in a store's grid layout, defined by a set of `(row, col)` cell positions.

- **Model** — `Zone` ORM model with `layout_version_id` FK (CASCADE delete), `name`, `color` (`#RRGGBB`), and a JSON `cells` column
- **Migration** — `e2f3a4b5c6d7_add_zones.py` chained after the `layout_versions` migration
- **Schemas** — `CellPosition`, `ZoneCreate` (min 1 cell, no duplicate cells), `ZoneUpdate` (all fields optional), `ZoneRead`
- **Service** — bounds checking (cell must be within `rows × cols`), zone-overlap detection (excluding self on update), and a `TODO(BE-08)` stub for fixture overlap
- **Routes** — 5 endpoints under `/api/stores/{store_id}/layouts/{layout_version_id}/zones`
- **Resolves all `TODO(BE-07)` markers** — `zones` relationship on `LayoutVersion`, `selectinload(LayoutVersion.zones)` in `get_active_layout`, and `zones: list[ZoneRead]` in `LayoutVersionRead`

| Method | Path | Auth | Status |
|---|---|---|---|
| `GET` | `/zones` | any member | 200 |
| `POST` | `/zones` | OWNER \| ADMIN | 201 |
| `GET` | `/zones/{zone_id}` | any member | 200 |
| `PUT` | `/zones/{zone_id}` | OWNER \| ADMIN | 200 |
| `DELETE` | `/zones/{zone_id}` | OWNER \| ADMIN | 204 |

## Why

Zones are the first spatial data layer on top of a layout grid. They allow store operators to mark regions of the floor plan (e.g. "Produce", "Dairy") before products and fixtures are placed. Unblocks BE-08 (fixtures).

## How to test

```bash
# Start services
docker compose up -d

# Apply migrations
make migrate          # or: DATABASE_URL=... alembic upgrade head

# Run the full test suite (69 tests)
make test-v2
```

Manual smoke test:

```bash
# 1. Create a layout version
POST /api/stores/{store_id}/layouts
{"rows": 5, "cols": 5}

# 2. Create a zone
POST /api/stores/{store_id}/layouts/{layout_version_id}/zones
{"name": "Produce", "color": "#00FF00", "cells": [{"row": 0, "col": 0}, {"row": 0, "col": 1}]}

# 3. Verify zones appear in active layout
GET /api/stores/{store_id}/layouts/active

# 4. Attempt overlap (should return 409)
POST /api/stores/{store_id}/layouts/{layout_version_id}/zones
{"name": "Dairy", "color": "#0000FF", "cells": [{"row": 0, "col": 0}]}

# 5. Attempt out-of-bounds cell (should return 400)
POST /api/stores/{store_id}/layouts/{layout_version_id}/zones
{"name": "OOB", "color": "#FF0000", "cells": [{"row": 99, "col": 0}]}
```

## Checklist
- [x] `make test` passes (69/69)
- [x] `make lint` passes (black + mypy)
- [x] No hardcoded secrets or credentials
- [ ] New env vars added to .env.example — _none added_
- [x] README updated if needed — _no user-facing changes_