### PR TITLE
feat: Add StoreInventory model, service, and CRUD endpoints

### DIFF
--- a/alembic/versions/a2b3c4d5e6f7_add_store_inventory.py
+++ b/alembic/versions/a2b3c4d5e6f7_add_store_inventory.py
@@ -1,0 +1,81 @@
+"""Add store_inventory table.
+
+Revision ID: a2b3c4d5e6f7
+Revises: f3a4b5c6d7e8
+Create Date: 2026-03-31 14:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers
+revision = "a2b3c4d5e6f7"
+down_revision = "f3a4b5c6d7e8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "store_inventory",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "store_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "product_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("quantity", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("unit_price", sa.Numeric(12, 4), nullable=True),
+        sa.Column("low_stock_threshold", sa.Float(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["store_id"],
+            ["stores.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["product_id"],
+            ["products.id"],
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "store_id",
+            "product_id",
+            name="uq_store_inventory_store_product",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_store_inventory_store_id", "store_inventory", ["store_id"]
+    )
+    op.create_index(
+        "ix_store_inventory_product_id", "store_inventory", ["product_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_store_inventory_product_id", table_name="store_inventory")
+    op.drop_index("ix_store_inventory_store_id", table_name="store_inventory")
+    op.drop_table("store_inventory")

--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ from app.zones.routes import router as zones_router
 from app.fixtures.routes import router as fixtures_router
 from app.stores.routes import router as stores_router
 from app.suppliers.routes import router as suppliers_router
+from app.store_inventory.routes import router as store_inventory_router
 
 # ── Structured JSON logging to stdout → Docker → CloudWatch ──
 handler = logging.StreamHandler(sys.stdout)
@@ -86,6 +87,7 @@ def create_app() -> FastAPI:
     app.include_router(suppliers_router)
     app.include_router(products_router)
     app.include_router(stores_router)
+    app.include_router(store_inventory_router)
     app.include_router(layouts_router)
     app.include_router(zones_router)
     app.include_router(fixtures_router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.store import Store
 from app.models.layout_version import LayoutVersion
 from app.models.zone import Zone
 from app.models.fixture import Fixture
+from app.models.store_inventory import StoreInventory
 
 __all__ = [
     "BaseModel",
@@ -22,4 +23,5 @@ __all__ = [
     "LayoutVersion",
     "Zone",
     "Fixture",
+    "StoreInventory",
 ]

--- a/app/models/store.py
+++ b/app/models/store.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, func
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import BaseModel
+
+if TYPE_CHECKING:
+    from app.models.store_inventory import StoreInventory
 
 
 class Store(BaseModel):
@@ -33,4 +37,10 @@ class Store(BaseModel):
         server_default=func.now(),
         onupdate=func.now(),
         nullable=False,
+    )
+
+    inventory: Mapped[list[StoreInventory]] = relationship(
+        "StoreInventory",
+        back_populates="store",
+        cascade="all, delete-orphan",
     )

--- a/app/models/store_inventory.py
+++ b/app/models/store_inventory.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import DateTime, Float, ForeignKey, Numeric, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import BaseModel
+
+
+class StoreInventory(BaseModel):
+    """Links a product to a store with quantity, optional pricing, and low-stock threshold."""
+
+    __tablename__ = "store_inventory"
+
+    store_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("stores.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    product_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("products.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    quantity: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    unit_price: Mapped[Decimal | None] = mapped_column(Numeric(12, 4), nullable=True)
+    low_stock_threshold: Mapped[float | None] = mapped_column(Float, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    store: Mapped[Store] = relationship("Store", back_populates="inventory")  # type: ignore[name-defined]
+    product: Mapped[Product] = relationship("Product")  # type: ignore[name-defined]
+
+    __table_args__ = (
+        UniqueConstraint(
+            "store_id", "product_id", name="uq_store_inventory_store_product"
+        ),
+    )

--- a/app/store_inventory/routes.py
+++ b/app/store_inventory/routes.py
@@ -9,7 +9,7 @@ from app.core.database import get_db
 from app.core.roles import OrgRole
 from app.models.org_membership import OrgMembership
 from app.models.store import Store
-from app.orgs.deps import RequireOrgRole, get_current_org_membership
+from app.orgs.deps import RequireOrgRole
 from app.stores.deps import get_store_from_path
 from app.store_inventory.schemas import (
     StoreInventoryCreate,
@@ -42,6 +42,7 @@ async def stock_product(
     entry = await add_product(
         db,
         store_id=store.id,
+        org_id=store.org_id,
         product_id=data.product_id,
         quantity=data.quantity,
         unit_price=data.unit_price,
@@ -82,9 +83,7 @@ async def update_inventory_entry(
         db,
         entry_id=entry_id,
         store_id=store.id,
-        quantity=data.quantity,
-        unit_price=data.unit_price,
-        low_stock_threshold=data.low_stock_threshold,
+        **{k: v for k, v in data.model_dump().items() if k in data.model_fields_set},
     )
     await db.commit()
     return entry

--- a/app/store_inventory/routes.py
+++ b/app/store_inventory/routes.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.roles import OrgRole
+from app.models.org_membership import OrgMembership
+from app.models.store import Store
+from app.orgs.deps import RequireOrgRole, get_current_org_membership
+from app.stores.deps import get_store_from_path
+from app.store_inventory.schemas import (
+    StoreInventoryCreate,
+    StoreInventoryRead,
+    StoreInventoryUpdate,
+)
+from app.store_inventory.service import (
+    add_product,
+    delete_entry,
+    get_entry,
+    list_inventory,
+    update_entry,
+)
+
+router = APIRouter(prefix="/api/stores/{store_id}/inventory", tags=["store-inventory"])
+
+
+@router.post(
+    "",
+    response_model=StoreInventoryRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def stock_product(
+    data: StoreInventoryCreate,
+    store: Store = Depends(get_store_from_path),
+    db: AsyncSession = Depends(get_db),
+) -> StoreInventoryRead:
+    """Add a product to this store's inventory."""
+    entry = await add_product(
+        db,
+        store_id=store.id,
+        product_id=data.product_id,
+        quantity=data.quantity,
+        unit_price=data.unit_price,
+        low_stock_threshold=data.low_stock_threshold,
+    )
+    await db.commit()
+    return StoreInventoryRead.model_validate(entry)
+
+
+@router.get("", response_model=list[StoreInventoryRead])
+async def get_store_inventory(
+    store: Store = Depends(get_store_from_path),
+    db: AsyncSession = Depends(get_db),
+) -> list[StoreInventoryRead]:
+    """List all inventory entries for this store."""
+    entries = await list_inventory(db, store_id=store.id)
+    return [StoreInventoryRead.model_validate(e) for e in entries]
+
+
+@router.get("/{entry_id}", response_model=StoreInventoryRead)
+async def get_inventory_entry(
+    entry_id: uuid.UUID,
+    store: Store = Depends(get_store_from_path),
+    db: AsyncSession = Depends(get_db),
+) -> StoreInventoryRead:
+    """Get a single inventory entry."""
+    entry = await get_entry(db, entry_id=entry_id, store_id=store.id)
+    return StoreInventoryRead.model_validate(entry)
+
+
+@router.patch("/{entry_id}", response_model=StoreInventoryRead)
+async def update_inventory_entry(
+    entry_id: uuid.UUID,
+    data: StoreInventoryUpdate,
+    store: Store = Depends(get_store_from_path),
+    db: AsyncSession = Depends(get_db),
+) -> StoreInventoryRead:
+    """Partially update an inventory entry."""
+    entry = await update_entry(
+        db,
+        entry_id=entry_id,
+        store_id=store.id,
+        quantity=data.quantity,
+        unit_price=data.unit_price,
+        low_stock_threshold=data.low_stock_threshold,
+    )
+    await db.commit()
+    return StoreInventoryRead.model_validate(entry)
+
+
+@router.delete("/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_inventory_entry(
+    entry_id: uuid.UUID,
+    store: Store = Depends(get_store_from_path),
+    _membership: OrgMembership = Depends(RequireOrgRole(OrgRole.OWNER)),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Delete an inventory entry. Owner role required."""
+    await delete_entry(db, entry_id=entry_id, store_id=store.id)
+    await db.commit()

--- a/app/store_inventory/routes.py
+++ b/app/store_inventory/routes.py
@@ -23,6 +23,7 @@ from app.store_inventory.service import (
     list_inventory,
     update_entry,
 )
+from app.models.store_inventory import StoreInventory
 
 router = APIRouter(prefix="/api/stores/{store_id}/inventory", tags=["store-inventory"])
 
@@ -36,7 +37,7 @@ async def stock_product(
     data: StoreInventoryCreate,
     store: Store = Depends(get_store_from_path),
     db: AsyncSession = Depends(get_db),
-) -> StoreInventoryRead:
+) -> StoreInventory:
     """Add a product to this store's inventory."""
     entry = await add_product(
         db,
@@ -47,17 +48,16 @@ async def stock_product(
         low_stock_threshold=data.low_stock_threshold,
     )
     await db.commit()
-    return StoreInventoryRead.model_validate(entry)
+    return entry
 
 
 @router.get("", response_model=list[StoreInventoryRead])
 async def get_store_inventory(
     store: Store = Depends(get_store_from_path),
     db: AsyncSession = Depends(get_db),
-) -> list[StoreInventoryRead]:
+) -> list[StoreInventory]:
     """List all inventory entries for this store."""
-    entries = await list_inventory(db, store_id=store.id)
-    return [StoreInventoryRead.model_validate(e) for e in entries]
+    return await list_inventory(db, store_id=store.id)
 
 
 @router.get("/{entry_id}", response_model=StoreInventoryRead)
@@ -65,10 +65,9 @@ async def get_inventory_entry(
     entry_id: uuid.UUID,
     store: Store = Depends(get_store_from_path),
     db: AsyncSession = Depends(get_db),
-) -> StoreInventoryRead:
+) -> StoreInventory:
     """Get a single inventory entry."""
-    entry = await get_entry(db, entry_id=entry_id, store_id=store.id)
-    return StoreInventoryRead.model_validate(entry)
+    return await get_entry(db, entry_id=entry_id, store_id=store.id)
 
 
 @router.patch("/{entry_id}", response_model=StoreInventoryRead)
@@ -77,7 +76,7 @@ async def update_inventory_entry(
     data: StoreInventoryUpdate,
     store: Store = Depends(get_store_from_path),
     db: AsyncSession = Depends(get_db),
-) -> StoreInventoryRead:
+) -> StoreInventory:
     """Partially update an inventory entry."""
     entry = await update_entry(
         db,
@@ -88,7 +87,7 @@ async def update_inventory_entry(
         low_stock_threshold=data.low_stock_threshold,
     )
     await db.commit()
-    return StoreInventoryRead.model_validate(entry)
+    return entry
 
 
 @router.delete("/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/app/store_inventory/schemas.py
+++ b/app/store_inventory/schemas.py
@@ -14,14 +14,16 @@ class StoreInventoryCreate(BaseModel):
         default=None, description="Per-unit price (optional)"
     )
     low_stock_threshold: float | None = Field(
-        default=None, description="Alert threshold for low stock (optional)"
+        default=None,
+        ge=0,
+        description="Alert threshold for low stock (optional)",
     )
 
 
 class StoreInventoryUpdate(BaseModel):
     quantity: float | None = Field(default=None, ge=0)
     unit_price: Decimal | None = None
-    low_stock_threshold: float | None = None
+    low_stock_threshold: float | None = Field(default=None, ge=0)
 
 
 class StoreInventoryRead(BaseModel):

--- a/app/store_inventory/schemas.py
+++ b/app/store_inventory/schemas.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+
+class StoreInventoryCreate(BaseModel):
+    product_id: uuid.UUID
+    quantity: float = Field(default=0.0, ge=0, description="Units in stock")
+    unit_price: Decimal | None = Field(
+        default=None, description="Per-unit price (optional)"
+    )
+    low_stock_threshold: float | None = Field(
+        default=None, description="Alert threshold for low stock (optional)"
+    )
+
+
+class StoreInventoryUpdate(BaseModel):
+    quantity: float | None = Field(default=None, ge=0)
+    unit_price: Decimal | None = None
+    low_stock_threshold: float | None = None
+
+
+class StoreInventoryRead(BaseModel):
+    id: uuid.UUID
+    store_id: uuid.UUID
+    product_id: uuid.UUID
+    quantity: float
+    unit_price: Decimal | None
+    low_stock_threshold: float | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/app/store_inventory/service.py
+++ b/app/store_inventory/service.py
@@ -32,9 +32,7 @@ async def add_product(
     """
     # Validate the product belongs to the same org as the store.
     product_result = await db.execute(
-        select(Product).where(
-            and_(Product.id == product_id, Product.org_id == org_id)
-        )
+        select(Product).where(and_(Product.id == product_id, Product.org_id == org_id))
     )
     if product_result.scalar_one_or_none() is None:
         raise NotFound(f"Product {product_id} not found in organization {org_id}")

--- a/app/store_inventory/service.py
+++ b/app/store_inventory/service.py
@@ -6,9 +6,11 @@ import uuid
 from decimal import Decimal
 
 from sqlalchemy import and_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import AppError, NotFound
+from app.models.product import Product
 from app.models.store_inventory import StoreInventory
 
 
@@ -16,6 +18,7 @@ async def add_product(
     db: AsyncSession,
     *,
     store_id: uuid.UUID,
+    org_id: uuid.UUID,
     product_id: uuid.UUID,
     quantity: float = 0.0,
     unit_price: Decimal | None = None,
@@ -24,8 +27,19 @@ async def add_product(
     """
     Add a product to a store's inventory.
 
+    Raises NotFound if the product does not exist in the org (tenant isolation).
     Raises 409 AppError if the product is already stocked in the store.
     """
+    # Validate the product belongs to the same org as the store.
+    product_result = await db.execute(
+        select(Product).where(
+            and_(Product.id == product_id, Product.org_id == org_id)
+        )
+    )
+    if product_result.scalar_one_or_none() is None:
+        raise NotFound(f"Product {product_id} not found in organization {org_id}")
+
+    # Pre-check for duplicates (common case — not concurrency-safe alone).
     existing = await db.execute(
         select(StoreInventory).where(
             and_(
@@ -48,8 +62,15 @@ async def add_product(
         low_stock_threshold=low_stock_threshold,
     )
     db.add(entry)
-    await db.flush()
-    await db.refresh(entry)
+    # Catch unique-constraint violation from concurrent inserts and surface as 409.
+    try:
+        await db.flush()
+        await db.refresh(entry)
+    except IntegrityError:
+        raise AppError(
+            f"Product {product_id} is already stocked in store {store_id}",
+            status_code=409,
+        )
     return entry
 
 
@@ -93,29 +114,36 @@ async def get_entry(
     return entry
 
 
+# Sentinel that distinguishes "argument not provided" from "explicitly set to None".
+# This allows clients to clear nullable fields (e.g. unit_price, low_stock_threshold)
+# by sending {"unit_price": null} in a PATCH request.
+_UNSET = object()
+
+
 async def update_entry(
     db: AsyncSession,
     *,
     entry_id: uuid.UUID,
     store_id: uuid.UUID,
-    quantity: float | None = None,
-    unit_price: Decimal | None = None,
-    low_stock_threshold: float | None = None,
+    quantity: float | None | object = _UNSET,
+    unit_price: Decimal | None | object = _UNSET,
+    low_stock_threshold: float | None | object = _UNSET,
 ) -> StoreInventory:
     """
     Partially update an inventory entry.
 
-    Only fields explicitly provided (not None) are changed.
+    Only fields explicitly provided are changed. Fields explicitly set to None
+    will be cleared when the underlying column is nullable.
     Raises NotFound if the entry does not exist.
     """
     entry = await get_entry(db, entry_id=entry_id, store_id=store_id)
 
-    if quantity is not None:
-        entry.quantity = quantity
-    if unit_price is not None:
-        entry.unit_price = unit_price
-    if low_stock_threshold is not None:
-        entry.low_stock_threshold = low_stock_threshold
+    if quantity is not _UNSET:
+        entry.quantity = quantity  # type: ignore[assignment]
+    if unit_price is not _UNSET:
+        entry.unit_price = unit_price  # type: ignore[assignment]
+    if low_stock_threshold is not _UNSET:
+        entry.low_stock_threshold = low_stock_threshold  # type: ignore[assignment]
 
     await db.flush()
     await db.refresh(entry)

--- a/app/store_inventory/service.py
+++ b/app/store_inventory/service.py
@@ -1,0 +1,138 @@
+"""Service layer for StoreInventory CRUD operations."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import AppError, NotFound
+from app.models.store_inventory import StoreInventory
+
+
+async def add_product(
+    db: AsyncSession,
+    *,
+    store_id: uuid.UUID,
+    product_id: uuid.UUID,
+    quantity: float = 0.0,
+    unit_price: Decimal | None = None,
+    low_stock_threshold: float | None = None,
+) -> StoreInventory:
+    """
+    Add a product to a store's inventory.
+
+    Raises 409 AppError if the product is already stocked in the store.
+    """
+    existing = await db.execute(
+        select(StoreInventory).where(
+            and_(
+                StoreInventory.store_id == store_id,
+                StoreInventory.product_id == product_id,
+            )
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise AppError(
+            f"Product {product_id} is already stocked in store {store_id}",
+            status_code=409,
+        )
+
+    entry = StoreInventory(
+        store_id=store_id,
+        product_id=product_id,
+        quantity=quantity,
+        unit_price=unit_price,
+        low_stock_threshold=low_stock_threshold,
+    )
+    db.add(entry)
+    await db.flush()
+    await db.refresh(entry)
+    return entry
+
+
+async def list_inventory(
+    db: AsyncSession,
+    *,
+    store_id: uuid.UUID,
+) -> list[StoreInventory]:
+    """Return all inventory entries for a store, ordered by creation time."""
+    stmt = (
+        select(StoreInventory)
+        .where(StoreInventory.store_id == store_id)
+        .order_by(StoreInventory.created_at)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_entry(
+    db: AsyncSession,
+    *,
+    entry_id: uuid.UUID,
+    store_id: uuid.UUID,
+) -> StoreInventory:
+    """
+    Get a single inventory entry by ID, scoped to the given store.
+
+    Raises NotFound if the entry does not exist or belongs to a different store.
+    """
+    result = await db.execute(
+        select(StoreInventory).where(
+            and_(
+                StoreInventory.id == entry_id,
+                StoreInventory.store_id == store_id,
+            )
+        )
+    )
+    entry = result.scalar_one_or_none()
+    if entry is None:
+        raise NotFound(f"Inventory entry {entry_id} not found in store {store_id}")
+    return entry
+
+
+async def update_entry(
+    db: AsyncSession,
+    *,
+    entry_id: uuid.UUID,
+    store_id: uuid.UUID,
+    quantity: float | None = None,
+    unit_price: Decimal | None = None,
+    low_stock_threshold: float | None = None,
+) -> StoreInventory:
+    """
+    Partially update an inventory entry.
+
+    Only fields explicitly provided (not None) are changed.
+    Raises NotFound if the entry does not exist.
+    """
+    entry = await get_entry(db, entry_id=entry_id, store_id=store_id)
+
+    if quantity is not None:
+        entry.quantity = quantity
+    if unit_price is not None:
+        entry.unit_price = unit_price
+    if low_stock_threshold is not None:
+        entry.low_stock_threshold = low_stock_threshold
+
+    await db.flush()
+    await db.refresh(entry)
+    return entry
+
+
+async def delete_entry(
+    db: AsyncSession,
+    *,
+    entry_id: uuid.UUID,
+    store_id: uuid.UUID,
+) -> None:
+    """
+    Delete an inventory entry.
+
+    Raises NotFound if the entry does not exist or belongs to a different store.
+    """
+    entry = await get_entry(db, entry_id=entry_id, store_id=store_id)
+    await db.delete(entry)
+    await db.flush()

--- a/testsv2/factories.py
+++ b/testsv2/factories.py
@@ -7,6 +7,7 @@ arguments let individual tests customise only the fields they care about.
 """
 
 import uuid
+from decimal import Decimal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -17,6 +18,7 @@ from app.models.org_membership import OrgMembership
 from app.models.product import Product
 from app.models.product_supplier import ProductSupplier
 from app.models.store import Store
+from app.models.store_inventory import StoreInventory
 from app.models.supplier import Supplier
 from app.models.user import User
 from app.models.fixture import Fixture, FixtureType
@@ -239,3 +241,25 @@ async def create_fixture(
     db.add(fixture)
     await db.flush()
     return fixture
+
+
+async def create_store_inventory(
+    db: AsyncSession,
+    *,
+    store_id: uuid.UUID,
+    product_id: uuid.UUID,
+    quantity: float = 0.0,
+    unit_price: Decimal | None = None,
+    low_stock_threshold: float | None = None,
+) -> StoreInventory:
+    """Insert a ``StoreInventory`` row and return it."""
+    entry = StoreInventory(
+        store_id=store_id,
+        product_id=product_id,
+        quantity=quantity,
+        unit_price=unit_price,
+        low_stock_threshold=low_stock_threshold,
+    )
+    db.add(entry)
+    await db.flush()
+    return entry

--- a/testsv2/functional/test_store_inventory_endpoints.py
+++ b/testsv2/functional/test_store_inventory_endpoints.py
@@ -128,9 +128,7 @@ async def test_list_inventory_empty(
     )
     store = await create_store(db, org_id=org.id)
 
-    response = await client.get(
-        _inventory_url(store.id), headers=_org_headers(org.id)
-    )
+    response = await client.get(_inventory_url(store.id), headers=_org_headers(org.id))
 
     assert response.status_code == 200
     assert response.json() == []
@@ -157,9 +155,7 @@ async def test_list_inventory_returns_entries(
         db, store_id=store.id, product_id=product_b.id, quantity=8.0
     )
 
-    response = await client.get(
-        _inventory_url(store.id), headers=_org_headers(org.id)
-    )
+    response = await client.get(_inventory_url(store.id), headers=_org_headers(org.id))
 
     assert response.status_code == 200
     product_ids = {e["product_id"] for e in response.json()}

--- a/testsv2/functional/test_store_inventory_endpoints.py
+++ b/testsv2/functional/test_store_inventory_endpoints.py
@@ -291,3 +291,50 @@ async def test_delete_inventory_entry_as_employee_returns_403(
     )
 
     assert response.status_code == 403
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_stock_product_as_employee_succeeds(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """POST is open to any org member, not just owners."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE
+    )
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+
+    response = await client.post(
+        _inventory_url(store.id),
+        json={"product_id": str(product.id)},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 201
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_stock_product_cross_org_product_returns_404(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """POST rejects a product_id that belongs to a different org (tenant isolation)."""
+    org = await create_org(db, name="Org A")
+    other_org = await create_org(db, name="Org B")
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    foreign_product = await create_product(db, org_id=other_org.id)
+
+    response = await client.post(
+        _inventory_url(store.id),
+        json={"product_id": str(foreign_product.id)},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 404

--- a/testsv2/functional/test_store_inventory_endpoints.py
+++ b/testsv2/functional/test_store_inventory_endpoints.py
@@ -1,0 +1,297 @@
+"""
+Functional tests for POST/GET/PATCH/DELETE /api/stores/{store_id}/inventory.
+
+Uses the real DB with transaction rollback, a real httpx AsyncClient,
+and bypasses Cognito auth via the ``bypass_auth`` fixture.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.roles import OrgRole
+from app.models.user import User
+from testsv2.factories import (
+    create_membership,
+    create_org,
+    create_product,
+    create_store,
+    create_store_inventory,
+)
+from testsv2.functional.conftest import AUTH_HEADER
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _org_headers(org_id) -> dict:
+    """Return auth + X-Org-Id headers for the given org."""
+    return {**AUTH_HEADER, "X-Org-Id": str(org_id)}
+
+
+def _inventory_url(store_id) -> str:
+    return f"/api/stores/{store_id}/inventory"
+
+
+# ── POST /api/stores/{store_id}/inventory ─────────────────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_stock_product_success(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """POST creates an inventory entry and returns 201 with a full payload."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+
+    response = await client.post(
+        _inventory_url(store.id),
+        json={"product_id": str(product.id), "quantity": 12.5, "unit_price": "3.99"},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["store_id"] == str(store.id)
+    assert body["product_id"] == str(product.id)
+    assert body["quantity"] == 12.5
+    assert body["unit_price"] == "3.9900"
+    assert "id" in body
+    assert "created_at" in body
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_stock_product_duplicate_returns_409(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Stocking the same product twice in the same store returns 409."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    await create_store_inventory(db, store_id=store.id, product_id=product.id)
+
+    response = await client.post(
+        _inventory_url(store.id),
+        json={"product_id": str(product.id)},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 409
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_stock_product_invalid_store_returns_404(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """POST to an unknown store returns 404."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    product = await create_product(db, org_id=org.id)
+    import uuid
+
+    response = await client.post(
+        _inventory_url(uuid.uuid4()),
+        json={"product_id": str(product.id)},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 404
+
+
+# ── GET /api/stores/{store_id}/inventory ──────────────────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_list_inventory_empty(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """GET returns an empty list when the store has no inventory."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+
+    response = await client.get(
+        _inventory_url(store.id), headers=_org_headers(org.id)
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_list_inventory_returns_entries(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """GET returns all inventory entries for the store."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    product_a = await create_product(db, org_id=org.id, name="Alpha")
+    product_b = await create_product(db, org_id=org.id, name="Beta")
+    await create_store_inventory(
+        db, store_id=store.id, product_id=product_a.id, quantity=5.0
+    )
+    await create_store_inventory(
+        db, store_id=store.id, product_id=product_b.id, quantity=8.0
+    )
+
+    response = await client.get(
+        _inventory_url(store.id), headers=_org_headers(org.id)
+    )
+
+    assert response.status_code == 200
+    product_ids = {e["product_id"] for e in response.json()}
+    assert str(product_a.id) in product_ids
+    assert str(product_b.id) in product_ids
+
+
+# ── GET /api/stores/{store_id}/inventory/{entry_id} ───────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_get_inventory_entry_success(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """GET single entry returns 200 with the correct payload."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    entry = await create_store_inventory(
+        db, store_id=store.id, product_id=product.id, quantity=7.0
+    )
+
+    response = await client.get(
+        f"{_inventory_url(store.id)}/{entry.id}", headers=_org_headers(org.id)
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == str(entry.id)
+    assert body["quantity"] == 7.0
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_get_inventory_entry_not_found(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """GET single entry returns 404 for an unknown entry ID."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    import uuid
+
+    response = await client.get(
+        f"{_inventory_url(store.id)}/{uuid.uuid4()}", headers=_org_headers(org.id)
+    )
+
+    assert response.status_code == 404
+
+
+# ── PATCH /api/stores/{store_id}/inventory/{entry_id} ─────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_update_inventory_entry_success(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """PATCH updates the specified fields and returns 200."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    entry = await create_store_inventory(
+        db, store_id=store.id, product_id=product.id, quantity=3.0
+    )
+
+    response = await client.patch(
+        f"{_inventory_url(store.id)}/{entry.id}",
+        json={"quantity": 99.0, "low_stock_threshold": 10.0},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["quantity"] == 99.0
+    assert body["low_stock_threshold"] == 10.0
+
+
+# ── DELETE /api/stores/{store_id}/inventory/{entry_id} ────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_delete_inventory_entry_as_owner(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """DELETE returns 204 when called by the org owner."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    entry = await create_store_inventory(db, store_id=store.id, product_id=product.id)
+
+    response = await client.delete(
+        f"{_inventory_url(store.id)}/{entry.id}", headers=_org_headers(org.id)
+    )
+
+    assert response.status_code == 204
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_delete_inventory_entry_as_employee_returns_403(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """DELETE returns 403 when called by a non-owner member."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.EMPLOYEE
+    )
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    entry = await create_store_inventory(db, store_id=store.id, product_id=product.id)
+
+    response = await client.delete(
+        f"{_inventory_url(store.id)}/{entry.id}", headers=_org_headers(org.id)
+    )
+
+    assert response.status_code == 403

--- a/testsv2/unit/test_store_inventory_service.py
+++ b/testsv2/unit/test_store_inventory_service.py
@@ -58,7 +58,9 @@ async def test_add_product_default_quantity_is_zero(db: AsyncSession) -> None:
     store = await create_store(db, org_id=org.id)
     product = await create_product(db, org_id=org.id)
 
-    entry = await add_product(db, store_id=store.id, org_id=org.id, product_id=product.id)
+    entry = await add_product(
+        db, store_id=store.id, org_id=org.id, product_id=product.id
+    )
 
     assert entry.quantity == 0.0
 

--- a/testsv2/unit/test_store_inventory_service.py
+++ b/testsv2/unit/test_store_inventory_service.py
@@ -36,6 +36,7 @@ async def test_add_product_creates_entry(db: AsyncSession) -> None:
     entry = await add_product(
         db,
         store_id=store.id,
+        org_id=org.id,
         product_id=product.id,
         quantity=10.0,
         unit_price=Decimal("4.99"),
@@ -57,7 +58,7 @@ async def test_add_product_default_quantity_is_zero(db: AsyncSession) -> None:
     store = await create_store(db, org_id=org.id)
     product = await create_product(db, org_id=org.id)
 
-    entry = await add_product(db, store_id=store.id, product_id=product.id)
+    entry = await add_product(db, store_id=store.id, org_id=org.id, product_id=product.id)
 
     assert entry.quantity == 0.0
 
@@ -71,9 +72,20 @@ async def test_add_product_duplicate_raises_409(db: AsyncSession) -> None:
     await create_store_inventory(db, store_id=store.id, product_id=product.id)
 
     with pytest.raises(AppError) as exc_info:
-        await add_product(db, store_id=store.id, product_id=product.id)
+        await add_product(db, store_id=store.id, org_id=org.id, product_id=product.id)
 
     assert exc_info.value.status_code == 409
+
+
+async def test_add_product_unknown_product_raises_not_found(db: AsyncSession) -> None:
+    """add_product raises NotFound when the product does not exist in the org."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    other_org = await create_org(db, name="Other Org")
+    product = await create_product(db, org_id=other_org.id)
+
+    with pytest.raises(NotFound):
+        await add_product(db, store_id=store.id, org_id=org.id, product_id=product.id)
 
 
 # ── list_inventory ────────────────────────────────────────────────────────────

--- a/testsv2/unit/test_store_inventory_service.py
+++ b/testsv2/unit/test_store_inventory_service.py
@@ -1,0 +1,220 @@
+"""
+Unit tests for app.store_inventory.service using the real DB
+with per-test transaction rollback (no HTTP layer).
+"""
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import AppError, NotFound
+from app.store_inventory.service import (
+    add_product,
+    delete_entry,
+    get_entry,
+    list_inventory,
+    update_entry,
+)
+from testsv2.factories import (
+    create_org,
+    create_product,
+    create_store,
+    create_store_inventory,
+)
+
+
+# ── add_product ───────────────────────────────────────────────────────────────
+
+
+async def test_add_product_creates_entry(db: AsyncSession) -> None:
+    """add_product returns a persisted StoreInventory entry with correct fields."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+
+    entry = await add_product(
+        db,
+        store_id=store.id,
+        product_id=product.id,
+        quantity=10.0,
+        unit_price=Decimal("4.99"),
+        low_stock_threshold=2.0,
+    )
+
+    assert entry.id is not None
+    assert entry.store_id == store.id
+    assert entry.product_id == product.id
+    assert entry.quantity == 10.0
+    assert entry.unit_price == Decimal("4.99")
+    assert entry.low_stock_threshold == 2.0
+    assert entry.created_at is not None
+
+
+async def test_add_product_default_quantity_is_zero(db: AsyncSession) -> None:
+    """add_product defaults quantity to 0.0 when not provided."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+
+    entry = await add_product(db, store_id=store.id, product_id=product.id)
+
+    assert entry.quantity == 0.0
+
+
+async def test_add_product_duplicate_raises_409(db: AsyncSession) -> None:
+    """add_product raises AppError(409) when the product is already in the store."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+
+    await create_store_inventory(db, store_id=store.id, product_id=product.id)
+
+    with pytest.raises(AppError) as exc_info:
+        await add_product(db, store_id=store.id, product_id=product.id)
+
+    assert exc_info.value.status_code == 409
+
+
+# ── list_inventory ────────────────────────────────────────────────────────────
+
+
+async def test_list_inventory_returns_entries(db: AsyncSession) -> None:
+    """list_inventory returns all entries for the store."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product_a = await create_product(db, org_id=org.id, name="Product A")
+    product_b = await create_product(db, org_id=org.id, name="Product B")
+
+    await create_store_inventory(db, store_id=store.id, product_id=product_a.id)
+    await create_store_inventory(db, store_id=store.id, product_id=product_b.id)
+
+    entries = await list_inventory(db, store_id=store.id)
+
+    assert len(entries) == 2
+    product_ids = {e.product_id for e in entries}
+    assert product_ids == {product_a.id, product_b.id}
+
+
+async def test_list_inventory_scoped_to_store(db: AsyncSession) -> None:
+    """list_inventory does not return entries from other stores."""
+    org = await create_org(db)
+    store_a = await create_store(db, org_id=org.id, name="Store A")
+    store_b = await create_store(db, org_id=org.id, name="Store B")
+    product = await create_product(db, org_id=org.id)
+
+    await create_store_inventory(db, store_id=store_b.id, product_id=product.id)
+
+    entries = await list_inventory(db, store_id=store_a.id)
+
+    assert entries == []
+
+
+async def test_list_inventory_empty(db: AsyncSession) -> None:
+    """list_inventory returns an empty list when the store has no inventory."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+
+    entries = await list_inventory(db, store_id=store.id)
+
+    assert entries == []
+
+
+# ── get_entry ─────────────────────────────────────────────────────────────────
+
+
+async def test_get_entry_success(db: AsyncSession) -> None:
+    """get_entry returns the correct entry when store matches."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    created = await create_store_inventory(
+        db, store_id=store.id, product_id=product.id, quantity=5.0
+    )
+
+    retrieved = await get_entry(db, entry_id=created.id, store_id=store.id)
+
+    assert retrieved.id == created.id
+    assert retrieved.quantity == 5.0
+
+
+async def test_get_entry_wrong_store_raises_not_found(db: AsyncSession) -> None:
+    """get_entry raises NotFound when the entry belongs to a different store."""
+    org = await create_org(db)
+    store_a = await create_store(db, org_id=org.id, name="Store A")
+    store_b = await create_store(db, org_id=org.id, name="Store B")
+    product = await create_product(db, org_id=org.id)
+    entry = await create_store_inventory(
+        db, store_id=store_a.id, product_id=product.id
+    )
+
+    with pytest.raises(NotFound):
+        await get_entry(db, entry_id=entry.id, store_id=store_b.id)
+
+
+async def test_get_entry_unknown_id_raises_not_found(db: AsyncSession) -> None:
+    """get_entry raises NotFound for a completely unknown entry ID."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+
+    with pytest.raises(NotFound):
+        await get_entry(db, entry_id=uuid.uuid4(), store_id=store.id)
+
+
+# ── update_entry ──────────────────────────────────────────────────────────────
+
+
+async def test_update_entry_partial(db: AsyncSession) -> None:
+    """update_entry only changes the supplied fields."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    entry = await create_store_inventory(
+        db,
+        store_id=store.id,
+        product_id=product.id,
+        quantity=3.0,
+        low_stock_threshold=1.0,
+    )
+
+    updated = await update_entry(
+        db, entry_id=entry.id, store_id=store.id, quantity=50.0
+    )
+
+    assert updated.quantity == 50.0
+    assert updated.low_stock_threshold == 1.0  # unchanged
+
+
+async def test_update_entry_not_found(db: AsyncSession) -> None:
+    """update_entry raises NotFound for an unknown entry ID."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+
+    with pytest.raises(NotFound):
+        await update_entry(db, entry_id=uuid.uuid4(), store_id=store.id, quantity=1.0)
+
+
+# ── delete_entry ──────────────────────────────────────────────────────────────
+
+
+async def test_delete_entry_removes_record(db: AsyncSession) -> None:
+    """delete_entry removes the entry so it can no longer be retrieved."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    entry = await create_store_inventory(db, store_id=store.id, product_id=product.id)
+
+    await delete_entry(db, entry_id=entry.id, store_id=store.id)
+
+    with pytest.raises(NotFound):
+        await get_entry(db, entry_id=entry.id, store_id=store.id)
+
+
+async def test_delete_entry_not_found(db: AsyncSession) -> None:
+    """delete_entry raises NotFound for an unknown entry ID."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+
+    with pytest.raises(NotFound):
+        await delete_entry(db, entry_id=uuid.uuid4(), store_id=store.id)

--- a/testsv2/unit/test_store_inventory_service.py
+++ b/testsv2/unit/test_store_inventory_service.py
@@ -24,7 +24,6 @@ from testsv2.factories import (
     create_store_inventory,
 )
 
-
 # ── add_product ───────────────────────────────────────────────────────────────
 
 
@@ -145,9 +144,7 @@ async def test_get_entry_wrong_store_raises_not_found(db: AsyncSession) -> None:
     store_a = await create_store(db, org_id=org.id, name="Store A")
     store_b = await create_store(db, org_id=org.id, name="Store B")
     product = await create_product(db, org_id=org.id)
-    entry = await create_store_inventory(
-        db, store_id=store_a.id, product_id=product.id
-    )
+    entry = await create_store_inventory(db, store_id=store_a.id, product_id=product.id)
 
     with pytest.raises(NotFound):
         await get_entry(db, entry_id=entry.id, store_id=store_b.id)


### PR DESCRIPTION
## What
Introduces the `StoreInventory` model linking stores and products, with full CRUD endpoints under `POST/GET/PATCH/DELETE /api/stores/{store_id}/inventory`.

- `StoreInventory` model with `quantity` (float), `unit_price` (Decimal, optional), `low_stock_threshold` (float, optional), and a unique constraint on `(store_id, product_id)`
- Alembic migration creating the `store_inventory` table with FK constraints and indexes
- Service layer with duplicate-check (409), org-scoped queries, and partial updates
- `DELETE` restricted to `ORG_OWNER` role; all other endpoints open to any org member
- `create_store_inventory` factory added to factories.py
- 13 unit tests + 10 functional HTTP tests

## Why
Core inventory entity needed for stock management. Resolves **BE-02**.

## How to test
```bash
make test-db          # spin up test postgres
make test-v2          # migrate + run full testsv2 suite
```

Key scenarios to verify manually:
- `POST /api/stores/{store_id}/inventory` — creates entry, returns 201
- Duplicate `POST` with same `product_id` → 409
- `DELETE` as `ORG_EMPLOYEE` → 403; as `ORG_OWNER` → 204

## Checklist
- [x] `make test` passes
- [x] `make lint` passes (black + mypy)
- [x] No hardcoded secrets or credentials
- [ ] New env vars added to .env.example
- [ ] README updated if needed