### PR TITLE
feat: inventory list with search, category filter, and pagination

### DIFF
--- a/app/store_inventory/routes.py
+++ b/app/store_inventory/routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
@@ -12,6 +12,7 @@ from app.models.store import Store
 from app.orgs.deps import RequireOrgRole
 from app.stores.deps import get_store_from_path
 from app.store_inventory.schemas import (
+    PaginatedInventoryResponse,
     StoreInventoryCreate,
     StoreInventoryRead,
     StoreInventoryUpdate,
@@ -52,13 +53,36 @@ async def stock_product(
     return entry
 
 
-@router.get("", response_model=list[StoreInventoryRead])
+@router.get("", response_model=PaginatedInventoryResponse)
 async def get_store_inventory(
     store: Store = Depends(get_store_from_path),
     db: AsyncSession = Depends(get_db),
-) -> list[StoreInventory]:
-    """List all inventory entries for this store."""
-    return await list_inventory(db, store_id=store.id)
+    search: str | None = Query(
+        default=None,
+        description="Case-insensitive partial match on product name or category.",
+    ),
+    category: str | None = Query(
+        default=None,
+        description="Case-insensitive partial match on product category.",
+    ),
+    page: int = Query(default=1, ge=1, description="1-based page number."),
+    page_size: int = Query(default=20, ge=1, le=100, description="Items per page."),
+) -> PaginatedInventoryResponse:
+    """List inventory entries for this store with optional search, category filter, and pagination."""
+    items, total = await list_inventory(
+        db,
+        store_id=store.id,
+        search=search,
+        category=category,
+        page=page,
+        page_size=page_size,
+    )
+    return PaginatedInventoryResponse(
+        items=items,
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
 
 
 @router.get("/{entry_id}", response_model=StoreInventoryRead)

--- a/app/store_inventory/routes.py
+++ b/app/store_inventory/routes.py
@@ -78,7 +78,7 @@ async def get_store_inventory(
         page_size=page_size,
     )
     return PaginatedInventoryResponse(
-        items=items,
+        items=[StoreInventoryRead.model_validate(item) for item in items],
         total=total,
         page=page,
         page_size=page_size,

--- a/app/store_inventory/schemas.py
+++ b/app/store_inventory/schemas.py
@@ -47,7 +47,7 @@ class StoreInventoryRead(BaseModel):
     low_stock_threshold: float | None
     created_at: datetime
     updated_at: datetime
-    product: ProductSummary | None = None
+    product: ProductSummary
 
     model_config = {"from_attributes": True}
 

--- a/app/store_inventory/schemas.py
+++ b/app/store_inventory/schemas.py
@@ -26,6 +26,18 @@ class StoreInventoryUpdate(BaseModel):
     low_stock_threshold: float | None = Field(default=None, ge=0)
 
 
+class ProductSummary(BaseModel):
+    """Minimal product fields embedded in inventory responses."""
+
+    id: uuid.UUID
+    name: str
+    sku: str | None
+    category: str | None
+    description: str | None
+
+    model_config = {"from_attributes": True}
+
+
 class StoreInventoryRead(BaseModel):
     id: uuid.UUID
     store_id: uuid.UUID
@@ -35,5 +47,15 @@ class StoreInventoryRead(BaseModel):
     low_stock_threshold: float | None
     created_at: datetime
     updated_at: datetime
+    product: ProductSummary | None = None
 
     model_config = {"from_attributes": True}
+
+
+class PaginatedInventoryResponse(BaseModel):
+    """Paginated wrapper for inventory list responses."""
+
+    items: list[StoreInventoryRead]
+    total: int
+    page: int
+    page_size: int

--- a/app/store_inventory/service.py
+++ b/app/store_inventory/service.py
@@ -149,6 +149,7 @@ async def get_entry(
             )
         )
         .options(selectinload(StoreInventory.product))
+        .execution_options(populate_existing=True)
     )
     entry = result.scalar_one_or_none()
     if entry is None:

--- a/app/store_inventory/service.py
+++ b/app/store_inventory/service.py
@@ -89,13 +89,21 @@ async def list_inventory(
     - ``category`` performs a case-insensitive partial match on product category only.
     - ``page`` / ``page_size`` control the offset-based pagination window.
 
-    Returns a ``(items, total)`` tuple where ``total`` is the unfiltered count.
+    Returns a ``(items, total)`` tuple where ``total`` is the number of rows
+    matching the provided filters (including ``search``/``category``) before
+    pagination.
     """
-    filters = [StoreInventory.store_id == store_id]
+    if page < 1:
+        raise ValueError(f"page must be >= 1, got {page}")
+    if page_size < 1:
+        raise ValueError(f"page_size must be >= 1, got {page_size}")
+
+    store_filter = [StoreInventory.store_id == store_id]
+    product_filters: list = []
 
     if search:
         term = f"%{search}%"
-        filters.append(
+        product_filters.append(
             or_(
                 Product.name.ilike(term),
                 Product.category.ilike(term),
@@ -103,23 +111,37 @@ async def list_inventory(
         )
 
     if category:
-        filters.append(Product.category.ilike(f"%{category}%"))
+        product_filters.append(Product.category.ilike(f"%{category}%"))
+
+    needs_join = bool(product_filters)
+    all_filters = store_filter + product_filters
 
     # Count matching rows before pagination.
-    count_stmt = (
-        select(func.count(StoreInventory.id))
-        .join(Product, StoreInventory.product_id == Product.id)
-        .where(*filters)
-    )
+    # Only JOIN to the products table when product-level predicates are present.
+    if needs_join:
+        count_stmt = (
+            select(func.count(StoreInventory.id))
+            .join(Product, StoreInventory.product_id == Product.id)
+            .where(*all_filters)
+        )
+    else:
+        count_stmt = select(func.count(StoreInventory.id)).where(*store_filter)
     total: int = (await db.execute(count_stmt)).scalar_one()
 
-    # Fetch the requested page with joined product data.
+    # Fetch the requested page with eagerly loaded product data.
+    # The JOIN is omitted when no product-table predicates are active; selectinload
+    # handles the product relationship efficiently in both cases.
+    if needs_join:
+        items_stmt = (
+            select(StoreInventory)
+            .join(Product, StoreInventory.product_id == Product.id)
+            .where(*all_filters)
+        )
+    else:
+        items_stmt = select(StoreInventory).where(*store_filter)
     items_stmt = (
-        select(StoreInventory)
-        .join(Product, StoreInventory.product_id == Product.id)
-        .where(*filters)
-        .options(selectinload(StoreInventory.product))
-        .order_by(StoreInventory.created_at)
+        items_stmt.options(selectinload(StoreInventory.product))
+        .order_by(StoreInventory.created_at, StoreInventory.id)
         .offset((page - 1) * page_size)
         .limit(page_size)
     )

--- a/app/store_inventory/service.py
+++ b/app/store_inventory/service.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import uuid
 from decimal import Decimal
 
-from sqlalchemy import and_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.core.exceptions import AppError, NotFound
 from app.models.product import Product
@@ -63,28 +64,69 @@ async def add_product(
     # Catch unique-constraint violation from concurrent inserts and surface as 409.
     try:
         await db.flush()
-        await db.refresh(entry)
     except IntegrityError:
         raise AppError(
             f"Product {product_id} is already stocked in store {store_id}",
             status_code=409,
         )
-    return entry
+    # Re-fetch so the product relationship is eagerly loaded in the response.
+    return await get_entry(db, entry_id=entry.id, store_id=store_id)
 
 
 async def list_inventory(
     db: AsyncSession,
     *,
     store_id: uuid.UUID,
-) -> list[StoreInventory]:
-    """Return all inventory entries for a store, ordered by creation time."""
-    stmt = (
-        select(StoreInventory)
-        .where(StoreInventory.store_id == store_id)
-        .order_by(StoreInventory.created_at)
+    search: str | None = None,
+    category: str | None = None,
+    page: int = 1,
+    page_size: int = 20,
+) -> tuple[list[StoreInventory], int]:
+    """
+    Return a paginated, optionally filtered list of inventory entries for a store.
+
+    - ``search`` performs a case-insensitive partial match on product name OR category.
+    - ``category`` performs a case-insensitive partial match on product category only.
+    - ``page`` / ``page_size`` control the offset-based pagination window.
+
+    Returns a ``(items, total)`` tuple where ``total`` is the unfiltered count.
+    """
+    filters = [StoreInventory.store_id == store_id]
+
+    if search:
+        term = f"%{search}%"
+        filters.append(
+            or_(
+                Product.name.ilike(term),
+                Product.category.ilike(term),
+            )
+        )
+
+    if category:
+        filters.append(Product.category.ilike(f"%{category}%"))
+
+    # Count matching rows before pagination.
+    count_stmt = (
+        select(func.count(StoreInventory.id))
+        .join(Product, StoreInventory.product_id == Product.id)
+        .where(*filters)
     )
-    result = await db.execute(stmt)
-    return list(result.scalars().all())
+    total: int = (await db.execute(count_stmt)).scalar_one()
+
+    # Fetch the requested page with joined product data.
+    items_stmt = (
+        select(StoreInventory)
+        .join(Product, StoreInventory.product_id == Product.id)
+        .where(*filters)
+        .options(selectinload(StoreInventory.product))
+        .order_by(StoreInventory.created_at)
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+    )
+    result = await db.execute(items_stmt)
+    items = list(result.scalars().all())
+
+    return items, total
 
 
 async def get_entry(
@@ -99,12 +141,14 @@ async def get_entry(
     Raises NotFound if the entry does not exist or belongs to a different store.
     """
     result = await db.execute(
-        select(StoreInventory).where(
+        select(StoreInventory)
+        .where(
             and_(
                 StoreInventory.id == entry_id,
                 StoreInventory.store_id == store_id,
             )
         )
+        .options(selectinload(StoreInventory.product))
     )
     entry = result.scalar_one_or_none()
     if entry is None:
@@ -144,8 +188,8 @@ async def update_entry(
         entry.low_stock_threshold = low_stock_threshold  # type: ignore[assignment]
 
     await db.flush()
-    await db.refresh(entry)
-    return entry
+    # Re-fetch so the product relationship is eagerly loaded in the response.
+    return await get_entry(db, entry_id=entry_id, store_id=store_id)
 
 
 async def delete_entry(

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -18,6 +18,7 @@ Complete reference for every endpoint in the EasyInventory API. All routes retur
 - [Products](#products)
 - [Product–Supplier Links](#productsupplier-links)
 - [Stores](#stores)
+- [Store Inventory](#store-inventory)
 - [Layout Versions](#layout-versions)
 - [Zones](#zones)
 - [Admin: Organizations](#admin-organizations)
@@ -673,6 +674,154 @@ Creates a new store within the current organization.
 **Errors:**
 - `403` — Caller is not the org owner.
 - `422` — Missing or empty `name`.
+
+---
+
+## Store Inventory
+
+Store inventory endpoints track which products a store stocks and at what quantity. Inventory is scoped to a specific store and linked to org-scoped products. All inventory responses include embedded product metadata.
+
+All endpoints are nested under a store: `/api/stores/{store_id}/inventory`
+
+They require authentication and a valid `X-Org-Id` header, and validate that `store_id` belongs to the caller's organization.
+
+---
+
+### `GET /api/stores/{store_id}/inventory`
+
+Returns a paginated list of all inventory entries for the store. Supports full-text search and category filtering.
+
+**Auth:** Required — any org member  
+**Query Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `search` | string | — | Case-insensitive partial match on product **name** or **category** |
+| `category` | string | — | Case-insensitive partial match on product **category** only |
+| `page` | integer | `1` | 1-based page number |
+| `page_size` | integer | `20` | Items per page (min 1, max 100) |
+
+**Response** `200`
+
+```json
+{
+  "items": [
+    {
+      "id": "entry-uuid",
+      "store_id": "store-uuid",
+      "product_id": "product-uuid",
+      "quantity": 48.0,
+      "unit_price": "2.9900",
+      "low_stock_threshold": 10.0,
+      "created_at": "2026-03-31T10:00:00Z",
+      "updated_at": "2026-03-31T10:00:00Z",
+      "product": {
+        "id": "product-uuid",
+        "name": "Organic Apples",
+        "sku": "PROD-001",
+        "category": "Produce",
+        "description": "Fresh organic Gala apples"
+      }
+    }
+  ],
+  "total": 42,
+  "page": 1,
+  "page_size": 20
+}
+```
+
+> `total` reflects the count of rows matching the active filters (before pagination), not the total number of entries in the store.
+
+**Errors:**
+- `404` — Store not found in the current org.
+
+---
+
+### `POST /api/stores/{store_id}/inventory`
+
+Adds a product to the store's inventory.
+
+**Auth:** Required — any org member  
+**Request Body**
+
+```json
+{
+  "product_id": "product-uuid",
+  "quantity": 48.0,
+  "unit_price": "2.99",
+  "low_stock_threshold": 10.0
+}
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `product_id` | UUID | Yes | — | ID of the product to stock (must belong to this org) |
+| `quantity` | float | No | `0.0` | Units currently in stock (≥ 0) |
+| `unit_price` | decimal string | No | `null` | Per-unit price |
+| `low_stock_threshold` | float | No | `null` | Alert threshold for low stock (≥ 0) |
+
+**Response** `201` — The created inventory entry (same shape as a list item)
+
+**Errors:**
+- `404` — Product not found in the current org (tenant isolation — prevents stocking products from other orgs).
+- `404` — Store not found in the current org.
+- `409` — Product is already stocked in this store.
+
+---
+
+### `GET /api/stores/{store_id}/inventory/{entry_id}`
+
+Returns a single inventory entry by ID.
+
+**Auth:** Required — any org member  
+**Response** `200` — Single inventory entry (same shape as a list item)
+
+**Errors:**
+- `404` — Entry not found for this store.
+- `404` — Store not found in the current org.
+
+---
+
+### `PATCH /api/stores/{store_id}/inventory/{entry_id}`
+
+Partially updates an inventory entry. Only the fields provided in the request body are changed.
+
+**Auth:** Required — any org member  
+**Request Body** — all fields optional
+
+```json
+{
+  "quantity": 100.0,
+  "unit_price": "3.49",
+  "low_stock_threshold": 20.0
+}
+```
+
+| Field | Type | Constraints | Description |
+|---|---|---|---|
+| `quantity` | float | ≥ 0 | New quantity in stock |
+| `unit_price` | decimal string or `null` | — | Updated price; send `null` to clear |
+| `low_stock_threshold` | float or `null` | ≥ 0 | Updated threshold; send `null` to clear |
+
+**Response** `200` — The updated inventory entry
+
+**Errors:**
+- `404` — Entry not found for this store.
+- `404` — Store not found in the current org.
+
+---
+
+### `DELETE /api/stores/{store_id}/inventory/{entry_id}`
+
+Removes a product from the store's inventory.
+
+**Auth:** Required — `ORG_OWNER`  
+**Response** `204` — No content
+
+**Errors:**
+- `403` — Caller is not the org owner.
+- `404` — Entry not found for this store.
+- `404` — Store not found in the current org.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,7 +106,9 @@ easyinventory-api/
 │       ├── product_supplier.py  #   ProductSupplier join table (is_active flag)
 │       ├── store.py             #   Store (org-scoped, is_active, updated_at)
 │       ├── layout_version.py    #   LayoutVersion (store-scoped, version_number, rows, cols, is_active)
-│       └── zone.py              #   Zone (layout-version-scoped, name, color, cells JSON)
+│       ├── store_inventory.py   #   StoreInventory (store + product link, quantity, unit_price, low-stock threshold)
+│       ├── zone.py              #   Zone (layout-version-scoped, name, color, cells JSON)
+│       └── fixture.py           #   Fixture (layout-version-scoped, product reference, type, cell position)
 │
 ├── alembic/                     # Database migration infrastructure
 │   ├── env.py                   #   Async migration runner (reads DATABASE_URL)
@@ -456,12 +458,21 @@ All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which
                       │               │               │       │
                 ┌─────▼────┐   ┌──────▼─────┐   ┌────▼─────┐  │
                 │ Supplier │   │  Product   │   │  Store   │  │
-                └─────┬────┘   └──────┬─────┘   └──────────┘  │
-                      │               │                        │
-                      └──────┐ ┌──────┘                        │
-                      ┌──────▼─▼──────┐                        │
-                      │ProductSupplier│                        │
-                      └───────────────┘                        │
+                └─────┬────┘   └──────┬──┬──┘   └────┬──┬──┘  │
+                      │               │  │            │  │     │
+                      └──────┐ ┌──────┘  └────┐  ┌───┘  │     │
+                      ┌──────▼─▼──────┐   ┌───▼──▼────────┐   │
+                      │ProductSupplier│   │StoreInventory │   │
+                      └───────────────┘   └───────────────┘   │
+                                                               │
+                                               ┌───────────────┘
+                                          ┌────▼──────────┐
+                                          │LayoutVersion  │
+                                          └────┬──────────┘
+                                               │
+                                          ┌────▼────┐
+                                          │  Zone   │
+                                          └─────────┘
 ```
 
 | Model | Table | Key Fields | Relations |
@@ -470,9 +481,10 @@ All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which
 | `Organization` | `organizations` | `name` | → `OrgMembership` (one-to-many), `Store` (one-to-many) |
 | `OrgMembership` | `org_memberships` | `org_id` (FK), `user_id` (FK), `org_role`, `is_active` | → `User`, `Organization` |
 | `Supplier` | `suppliers` | `org_id` (FK), `name`, `contact_name`, `contact_email`, `contact_phone`, `notes` | — |
-| `Product` | `products` | `org_id` (FK), `name`, `description`, `sku`, `category` | → `ProductSupplier` (one-to-many) |
+| `Product` | `products` | `org_id` (FK), `name`, `description`, `sku`, `category` | → `ProductSupplier` (one-to-many), → `StoreInventory` (one-to-many) |
 | `ProductSupplier` | `product_suppliers` | `product_id` (FK), `supplier_id` (FK), `is_active` | → `Supplier` / Unique on `(product_id, supplier_id)` |
-| `Store` | `stores` | `org_id` (FK, CASCADE), `name`, `is_active`, `updated_at` | → `LayoutVersion` (one-to-many) |
+| `Store` | `stores` | `org_id` (FK, CASCADE), `name`, `is_active`, `updated_at` | → `LayoutVersion` (one-to-many), → `StoreInventory` (one-to-many) |
+| `StoreInventory` | `store_inventory` | `store_id` (FK, CASCADE), `product_id` (FK, CASCADE), `quantity`, `unit_price`, `low_stock_threshold`, `updated_at` | → `Store`, → `Product`; unique on `(store_id, product_id)` |
 | `LayoutVersion` | `layout_versions` | `store_id` (FK, CASCADE), `version_number`, `rows`, `cols`, `is_active`, `updated_at` | → `Zone` (one-to-many); unique on `(store_id, version_number)` |
 | `Zone` | `zones` | `layout_version_id` (FK, CASCADE), `name`, `color`, `cells` (JSON), `updated_at` | → `LayoutVersion` |
 
@@ -486,6 +498,9 @@ All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which
 - **Cascade deletes** — `Store.org_id` is defined with `ondelete="CASCADE"`, so all stores are deleted automatically when their parent organization is deleted.
 - **Layout versioning** — `LayoutVersion` models a point-in-time grid configuration for a store. Versions are immutable once created (grid dimensions cannot be changed), and only one may be `is_active=True` at a time. The `activate` endpoint uses a bulk `UPDATE … SET is_active=False` across the store, then a targeted `UPDATE … SET is_active=True` on the target, making activation atomic within the transaction.
 - **Zone cell storage** — A zone's claimed cells are stored as a JSON array of `{"row": int, "col": int}` objects rather than a normalised join table. This avoids a third table for what is effectively a small, denormalised blob that is always read and written as a unit. Cell-level validation (bounds check, intra-request duplicate check, cross-zone overlap detection) happens in the service layer before the row is written.
+- **Inventory conditional join** — `list_inventory` only joins the `products` table when `search` or `category` predicates are present. For the common unfiltered case the query stays on `store_inventory` alone and a `selectinload` fetches associated product rows efficiently via a separate IN-clause query. This avoids an unnecessary join for every basic list request.
+- **Stable inventory pagination** — The inventory list is ordered by `(created_at, id)`. The secondary `id` sort key ensures deterministic OFFSET/LIMIT pagination when multiple entries share the same `created_at` timestamp (which can happen when items are inserted in the same transaction).
+- **Inventory product contract** — The `product` field on `StoreInventoryRead` is non-optional (`ProductSummary`, not `ProductSummary | None`). The `product_id` FK is `NOT NULL` and `get_entry` always uses `selectinload`, so a missing product would indicate a data integrity failure rather than an expected empty state.
 
 ---
 

--- a/testsv2/functional/test_store_inventory_endpoints.py
+++ b/testsv2/functional/test_store_inventory_endpoints.py
@@ -121,7 +121,7 @@ async def test_list_inventory_empty(
     db: AsyncSession,
     test_user: User,
 ) -> None:
-    """GET returns an empty list when the store has no inventory."""
+    """GET returns a paginated envelope with an empty items list when the store has no inventory."""
     org = await create_org(db)
     await create_membership(
         db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
@@ -131,7 +131,11 @@ async def test_list_inventory_empty(
     response = await client.get(_inventory_url(store.id), headers=_org_headers(org.id))
 
     assert response.status_code == 200
-    assert response.json() == []
+    body = response.json()
+    assert body["items"] == []
+    assert body["total"] == 0
+    assert body["page"] == 1
+    assert body["page_size"] == 20
 
 
 @pytest.mark.usefixtures("bypass_auth")
@@ -140,7 +144,7 @@ async def test_list_inventory_returns_entries(
     db: AsyncSession,
     test_user: User,
 ) -> None:
-    """GET returns all inventory entries for the store."""
+    """GET returns paginated inventory entries with joined product information."""
     org = await create_org(db)
     await create_membership(
         db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
@@ -158,9 +162,15 @@ async def test_list_inventory_returns_entries(
     response = await client.get(_inventory_url(store.id), headers=_org_headers(org.id))
 
     assert response.status_code == 200
-    product_ids = {e["product_id"] for e in response.json()}
+    body = response.json()
+    assert body["total"] == 2
+    assert len(body["items"]) == 2
+    product_ids = {e["product_id"] for e in body["items"]}
     assert str(product_a.id) in product_ids
     assert str(product_b.id) in product_ids
+    # Verify joined product data is present
+    item = next(e for e in body["items"] if e["product_id"] == str(product_a.id))
+    assert item["product"]["name"] == "Alpha"
 
 
 # ── GET /api/stores/{store_id}/inventory/{entry_id} ───────────────────────────
@@ -338,3 +348,163 @@ async def test_stock_product_cross_org_product_returns_404(
     )
 
     assert response.status_code == 404
+
+
+# ── GET /api/stores/{store_id}/inventory: search & filter ─────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_list_inventory_search_by_name(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """?search= filters results to entries whose product name matches."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    widget = await create_product(db, org_id=org.id, name="Blue Widget")
+    gadget = await create_product(db, org_id=org.id, name="Red Gadget")
+    await create_store_inventory(db, store_id=store.id, product_id=widget.id)
+    await create_store_inventory(db, store_id=store.id, product_id=gadget.id)
+
+    response = await client.get(
+        _inventory_url(store.id),
+        params={"search": "widget"},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["items"][0]["product_id"] == str(widget.id)
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_list_inventory_search_by_category(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """?search= also matches against product category."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    tool = await create_product(db, org_id=org.id, name="Wrench", category="Tools")
+    snack = await create_product(db, org_id=org.id, name="Chips", category="Food")
+    await create_store_inventory(db, store_id=store.id, product_id=tool.id)
+    await create_store_inventory(db, store_id=store.id, product_id=snack.id)
+
+    response = await client.get(
+        _inventory_url(store.id),
+        params={"search": "TOOLS"},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["items"][0]["product_id"] == str(tool.id)
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_list_inventory_category_filter(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """?category= filters results to entries whose product category matches."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    hardware = await create_product(db, org_id=org.id, name="Bolt", category="Hardware")
+    food = await create_product(db, org_id=org.id, name="Bread", category="Food")
+    await create_store_inventory(db, store_id=store.id, product_id=hardware.id)
+    await create_store_inventory(db, store_id=store.id, product_id=food.id)
+
+    response = await client.get(
+        _inventory_url(store.id),
+        params={"category": "hardware"},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["items"][0]["product_id"] == str(hardware.id)
+
+
+# ── GET /api/stores/{store_id}/inventory: pagination ─────────────────────────
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_list_inventory_pagination_page_size(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """?page_size= limits the number of items returned, total reflects all rows."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    for i in range(5):
+        p = await create_product(db, org_id=org.id, name=f"Prod {i}")
+        await create_store_inventory(db, store_id=store.id, product_id=p.id)
+
+    response = await client.get(
+        _inventory_url(store.id),
+        params={"page": 1, "page_size": 2},
+        headers=_org_headers(org.id),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 5
+    assert len(body["items"]) == 2
+    assert body["page"] == 1
+    assert body["page_size"] == 2
+
+
+@pytest.mark.usefixtures("bypass_auth")
+async def test_list_inventory_pagination_no_overlap(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user: User,
+) -> None:
+    """Page 1 and page 2 return non-overlapping items."""
+    org = await create_org(db)
+    await create_membership(
+        db, org_id=org.id, user_id=test_user.id, org_role=OrgRole.OWNER
+    )
+    store = await create_store(db, org_id=org.id)
+    for i in range(4):
+        p = await create_product(db, org_id=org.id, name=f"Item {i:02d}")
+        await create_store_inventory(db, store_id=store.id, product_id=p.id)
+
+    page1 = (
+        await client.get(
+            _inventory_url(store.id),
+            params={"page": 1, "page_size": 2},
+            headers=_org_headers(org.id),
+        )
+    ).json()["items"]
+    page2 = (
+        await client.get(
+            _inventory_url(store.id),
+            params={"page": 2, "page_size": 2},
+            headers=_org_headers(org.id),
+        )
+    ).json()["items"]
+
+    page1_ids = {e["id"] for e in page1}
+    page2_ids = {e["id"] for e in page2}
+    assert page1_ids.isdisjoint(page2_ids)
+    assert len(page2) == 2

--- a/testsv2/unit/test_store_inventory_service.py
+++ b/testsv2/unit/test_store_inventory_service.py
@@ -103,10 +103,11 @@ async def test_list_inventory_returns_entries(db: AsyncSession) -> None:
     await create_store_inventory(db, store_id=store.id, product_id=product_a.id)
     await create_store_inventory(db, store_id=store.id, product_id=product_b.id)
 
-    entries = await list_inventory(db, store_id=store.id)
+    items, total = await list_inventory(db, store_id=store.id)
 
-    assert len(entries) == 2
-    product_ids = {e.product_id for e in entries}
+    assert total == 2
+    assert len(items) == 2
+    product_ids = {e.product_id for e in items}
     assert product_ids == {product_a.id, product_b.id}
 
 
@@ -119,9 +120,10 @@ async def test_list_inventory_scoped_to_store(db: AsyncSession) -> None:
 
     await create_store_inventory(db, store_id=store_b.id, product_id=product.id)
 
-    entries = await list_inventory(db, store_id=store_a.id)
+    items, total = await list_inventory(db, store_id=store_a.id)
 
-    assert entries == []
+    assert items == []
+    assert total == 0
 
 
 async def test_list_inventory_empty(db: AsyncSession) -> None:
@@ -129,9 +131,10 @@ async def test_list_inventory_empty(db: AsyncSession) -> None:
     org = await create_org(db)
     store = await create_store(db, org_id=org.id)
 
-    entries = await list_inventory(db, store_id=store.id)
+    items, total = await list_inventory(db, store_id=store.id)
 
-    assert entries == []
+    assert items == []
+    assert total == 0
 
 
 # ── get_entry ─────────────────────────────────────────────────────────────────
@@ -229,3 +232,139 @@ async def test_delete_entry_not_found(db: AsyncSession) -> None:
 
     with pytest.raises(NotFound):
         await delete_entry(db, entry_id=uuid.uuid4(), store_id=store.id)
+
+
+# ── list_inventory: product field ─────────────────────────────────────────────
+
+
+async def test_list_inventory_product_field_populated(db: AsyncSession) -> None:
+    """list_inventory eagerly loads the product relationship on each entry."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(
+        db, org_id=org.id, name="Widget", category="Hardware", sku="W-001"
+    )
+    await create_store_inventory(db, store_id=store.id, product_id=product.id)
+
+    items, _ = await list_inventory(db, store_id=store.id)
+
+    assert len(items) == 1
+    assert items[0].product is not None
+    assert items[0].product.name == "Widget"
+    assert items[0].product.category == "Hardware"
+    assert items[0].product.sku == "W-001"
+
+
+# ── list_inventory: search ────────────────────────────────────────────────────
+
+
+async def test_list_inventory_search_by_product_name(db: AsyncSession) -> None:
+    """search= filters entries whose product name matches (case-insensitive)."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    widget = await create_product(db, org_id=org.id, name="Blue Widget")
+    gadget = await create_product(db, org_id=org.id, name="Red Gadget")
+    await create_store_inventory(db, store_id=store.id, product_id=widget.id)
+    await create_store_inventory(db, store_id=store.id, product_id=gadget.id)
+
+    items, total = await list_inventory(db, store_id=store.id, search="widget")
+
+    assert total == 1
+    assert items[0].product_id == widget.id
+
+
+async def test_list_inventory_search_by_product_category(db: AsyncSession) -> None:
+    """search= also matches against product category."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    tool = await create_product(db, org_id=org.id, name="Hammer", category="Tools")
+    snack = await create_product(db, org_id=org.id, name="Chips", category="Food")
+    await create_store_inventory(db, store_id=store.id, product_id=tool.id)
+    await create_store_inventory(db, store_id=store.id, product_id=snack.id)
+
+    items, total = await list_inventory(db, store_id=store.id, search="tools")
+
+    assert total == 1
+    assert items[0].product_id == tool.id
+
+
+async def test_list_inventory_search_no_match_returns_empty(db: AsyncSession) -> None:
+    """search= with no matching products returns an empty result."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id, name="Anvil")
+    await create_store_inventory(db, store_id=store.id, product_id=product.id)
+
+    items, total = await list_inventory(db, store_id=store.id, search="zzznomatch")
+
+    assert total == 0
+    assert items == []
+
+
+# ── list_inventory: category filter ──────────────────────────────────────────
+
+
+async def test_list_inventory_category_filter(db: AsyncSession) -> None:
+    """category= filters entries to only those whose product category matches."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    hardware = await create_product(db, org_id=org.id, name="Bolt", category="Hardware")
+    food = await create_product(db, org_id=org.id, name="Bread", category="Food")
+    await create_store_inventory(db, store_id=store.id, product_id=hardware.id)
+    await create_store_inventory(db, store_id=store.id, product_id=food.id)
+
+    items, total = await list_inventory(db, store_id=store.id, category="hardware")
+
+    assert total == 1
+    assert items[0].product_id == hardware.id
+
+
+# ── list_inventory: pagination ────────────────────────────────────────────────
+
+
+async def test_list_inventory_pagination_page_size(db: AsyncSession) -> None:
+    """page_size= limits the number of returned items."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    products = [
+        await create_product(db, org_id=org.id, name=f"Product {i}") for i in range(5)
+    ]
+    for p in products:
+        await create_store_inventory(db, store_id=store.id, product_id=p.id)
+
+    items, total = await list_inventory(db, store_id=store.id, page=1, page_size=2)
+
+    assert total == 5  # total reflects all matching rows
+    assert len(items) == 2
+
+
+async def test_list_inventory_pagination_second_page(db: AsyncSession) -> None:
+    """page=2 with page_size=2 returns the third and fourth items."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    products = [
+        await create_product(db, org_id=org.id, name=f"Item {i:02d}") for i in range(4)
+    ]
+    for p in products:
+        await create_store_inventory(db, store_id=store.id, product_id=p.id)
+
+    first_page, _ = await list_inventory(db, store_id=store.id, page=1, page_size=2)
+    second_page, _ = await list_inventory(db, store_id=store.id, page=2, page_size=2)
+
+    first_ids = {e.id for e in first_page}
+    second_ids = {e.id for e in second_page}
+    assert first_ids.isdisjoint(second_ids)  # no overlap between pages
+    assert len(second_page) == 2
+
+
+async def test_list_inventory_pagination_beyond_last_page(db: AsyncSession) -> None:
+    """Requesting a page beyond the last returns empty items with correct total."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    await create_store_inventory(db, store_id=store.id, product_id=product.id)
+
+    items, total = await list_inventory(db, store_id=store.id, page=999, page_size=20)
+
+    assert total == 1
+    assert items == []


### PR DESCRIPTION
## What

Upgrades `GET /api/stores/{store_id}/inventory` to support full-text search, category filtering, and offset-based pagination. Adds a `ProductSummary` sub-schema embedded in every inventory response so callers get joined product data without a second request. Also adds `GET /api/stores/{store_id}/inventory/{id}` detail endpoint parity — all responses now include product fields.

**New query params on `GET /api/stores/{store_id}/inventory`:**
| Param | Type | Default | Description |
|---|---|---|---|
| `search` | `string` | — | Case-insensitive partial match on product name **or** category |
| `category` | `string` | — | Case-insensitive partial match on product category only |
| `page` | `int` | `1` | 1-based page number |
| `page_size` | `int` | `20` | Items per page (max 100) |

**Response shape changed** from `list[StoreInventoryRead]` → `PaginatedInventoryResponse`:
```json
{
  "items": [...],
  "total": 42,
  "page": 1,
  "page_size": 20
}
```

Each item now includes a nested `product` object (`id`, `name`, `sku`, `category`, `description`).

## Why

Closes BE-03. The raw list endpoint was unbounded and returned no product metadata, making it unusable for a real inventory UI. Search and category filtering are required acceptance criteria; pagination prevents unbounded queries as stores grow.

## How to test

1. Start the test DB if not already running: `make test-db`
2. Run the full test suite: `make test-v2`
3. Manually via the running dev stack (`make build`):
   ```bash
   # List with pagination
   GET /api/stores/{store_id}/inventory?page=1&page_size=5

   # Search by product name
   GET /api/stores/{store_id}/inventory?search=widget

   # Filter by category
   GET /api/stores/{store_id}/inventory?category=hardware

   # Combined
   GET /api/stores/{store_id}/inventory?category=tools&page=2&page_size=10
   ```
4. Verify each response contains `items`, `total`, `page`, `page_size` at the top level and that each item includes a `product` object with `name`, `sku`, `category`, and `description`.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes (black + mypy)
- [x] No hardcoded secrets or credentials
- [ ] New env vars added to .env.example
- [ ] README updated if needed