### PR TITLE
feat: inventory movements — receipt and sale recording

### DIFF
--- a/alembic/versions/b4c5d6e7f8a9_add_inventory_movements.py
+++ b/alembic/versions/b4c5d6e7f8a9_add_inventory_movements.py
@@ -17,8 +17,6 @@ depends_on = None
 
 
 def upgrade() -> None:
-    movement_type = sa.Enum("receipt", "sale", name="movement_type", create_type=True)
-
     op.create_table(
         "inventory_movements",
         sa.Column(
@@ -32,7 +30,11 @@ def upgrade() -> None:
             postgresql.UUID(as_uuid=True),
             nullable=False,
         ),
-        sa.Column("movement_type", movement_type, nullable=False),
+        sa.Column(
+            "movement_type",
+            sa.Enum("receipt", "sale", name="movement_type", create_type=True),
+            nullable=False,
+        ),
         sa.Column("quantity", sa.Integer(), nullable=False),
         sa.Column("unit_cost", sa.Numeric(10, 2), nullable=True),
         sa.Column("unit_price", sa.Numeric(10, 2), nullable=True),

--- a/alembic/versions/b4c5d6e7f8a9_add_inventory_movements.py
+++ b/alembic/versions/b4c5d6e7f8a9_add_inventory_movements.py
@@ -83,4 +83,4 @@ def downgrade() -> None:
         table_name="inventory_movements",
     )
     op.drop_table("inventory_movements")
-    op.execute("DROP TYPE movement_type")
+    op.execute("DROP TYPE IF EXISTS movement_type")

--- a/alembic/versions/b4c5d6e7f8a9_add_inventory_movements.py
+++ b/alembic/versions/b4c5d6e7f8a9_add_inventory_movements.py
@@ -1,0 +1,86 @@
+"""Add inventory_movements table.
+
+Revision ID: b4c5d6e7f8a9
+Revises: a2b3c4d5e6f7
+Create Date: 2026-03-31 15:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers
+revision = "b4c5d6e7f8a9"
+down_revision = "a2b3c4d5e6f7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    movement_type = sa.Enum("receipt", "sale", name="movement_type", create_type=True)
+
+    op.create_table(
+        "inventory_movements",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "store_inventory_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("movement_type", movement_type, nullable=False),
+        sa.Column("quantity", sa.Integer(), nullable=False),
+        sa.Column("unit_cost", sa.Numeric(10, 2), nullable=True),
+        sa.Column("unit_price", sa.Numeric(10, 2), nullable=True),
+        sa.Column("reference_number", sa.String(100), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "performed_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["store_inventory_id"],
+            ["store_inventory.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["performed_by_user_id"],
+            ["users.id"],
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_inventory_movements_store_inventory_id",
+        "inventory_movements",
+        ["store_inventory_id"],
+    )
+    op.create_index(
+        "ix_inventory_movements_performed_by_user_id",
+        "inventory_movements",
+        ["performed_by_user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_inventory_movements_performed_by_user_id",
+        table_name="inventory_movements",
+    )
+    op.drop_index(
+        "ix_inventory_movements_store_inventory_id",
+        table_name="inventory_movements",
+    )
+    op.drop_table("inventory_movements")
+    op.execute("DROP TYPE movement_type")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -10,6 +10,7 @@ from app.models.layout_version import LayoutVersion
 from app.models.zone import Zone
 from app.models.fixture import Fixture
 from app.models.store_inventory import StoreInventory
+from app.models.inventory_movement import InventoryMovement, MovementType
 
 __all__ = [
     "BaseModel",
@@ -24,4 +25,6 @@ __all__ = [
     "Zone",
     "Fixture",
     "StoreInventory",
+    "InventoryMovement",
+    "MovementType",
 ]

--- a/app/models/inventory_movement.py
+++ b/app/models/inventory_movement.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from enum import Enum as PyEnum
+
+from sqlalchemy import Enum, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import BaseModel
+
+
+class MovementType(PyEnum):
+    """Inventory movement type enumeration."""
+
+    RECEIPT = "receipt"
+    SALE = "sale"
+
+
+class InventoryMovement(BaseModel):
+    """Record of inventory quantity changes with full audit trail."""
+
+    __tablename__ = "inventory_movements"
+
+    store_inventory_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("store_inventory.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    movement_type: Mapped[MovementType] = mapped_column(
+        Enum(MovementType, name="movement_type"),
+        nullable=False,
+    )
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False)
+    unit_cost: Mapped[Decimal | None] = mapped_column(Numeric(10, 2), nullable=True)
+    unit_price: Mapped[Decimal | None] = mapped_column(Numeric(10, 2), nullable=True)
+    reference_number: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    performed_by_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    # created_at inherited from BaseModel

--- a/app/models/inventory_movement.py
+++ b/app/models/inventory_movement.py
@@ -30,7 +30,12 @@ class InventoryMovement(BaseModel):
         index=True,
     )
     movement_type: Mapped[MovementType] = mapped_column(
-        Enum(MovementType, name="movement_type"),
+        Enum(
+            MovementType,
+            values_callable=lambda x: [e.value for e in x],
+            name="movement_type",
+            create_type=False,
+        ),
         nullable=False,
     )
     quantity: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/app/store_inventory/routes.py
+++ b/app/store_inventory/routes.py
@@ -9,10 +9,14 @@ from app.core.database import get_db
 from app.core.roles import OrgRole
 from app.models.org_membership import OrgMembership
 from app.models.store import Store
-from app.orgs.deps import RequireOrgRole
+from app.models.inventory_movement import InventoryMovement
+from app.orgs.deps import RequireOrgRole, get_current_org_membership
 from app.stores.deps import get_store_from_path
 from app.store_inventory.schemas import (
+    MovementRead,
     PaginatedInventoryResponse,
+    RecordReceiptRequest,
+    RecordSaleRequest,
     StoreInventoryCreate,
     StoreInventoryRead,
     StoreInventoryUpdate,
@@ -22,6 +26,8 @@ from app.store_inventory.service import (
     delete_entry,
     get_entry,
     list_inventory,
+    record_receipt,
+    record_sale,
     update_entry,
 )
 from app.models.store_inventory import StoreInventory
@@ -123,3 +129,31 @@ async def delete_inventory_entry(
     """Delete an inventory entry. Owner role required."""
     await delete_entry(db, entry_id=entry_id, store_id=store.id)
     await db.commit()
+
+
+@router.post("/{inventory_id}/receipts", response_model=MovementRead, status_code=201)
+async def record_inventory_receipt(
+    inventory_id: uuid.UUID,
+    data: RecordReceiptRequest,
+    store: Store = Depends(get_store_from_path),
+    db: AsyncSession = Depends(get_db),
+    membership: OrgMembership = Depends(get_current_org_membership),
+) -> InventoryMovement:
+    """Record an inventory receipt (incoming stock)."""
+    movement = await record_receipt(db, inventory_id, data, membership.user_id)
+    await db.commit()
+    return movement
+
+
+@router.post("/{inventory_id}/sales", response_model=MovementRead, status_code=201)
+async def record_inventory_sale(
+    inventory_id: uuid.UUID,
+    data: RecordSaleRequest,
+    store: Store = Depends(get_store_from_path),
+    db: AsyncSession = Depends(get_db),
+    membership: OrgMembership = Depends(get_current_org_membership),
+) -> InventoryMovement:
+    """Record an inventory sale (outgoing stock)."""
+    movement = await record_sale(db, inventory_id, data, membership.user_id)
+    await db.commit()
+    return movement

--- a/app/store_inventory/routes.py
+++ b/app/store_inventory/routes.py
@@ -140,7 +140,9 @@ async def record_inventory_receipt(
     membership: OrgMembership = Depends(get_current_org_membership),
 ) -> InventoryMovement:
     """Record an inventory receipt (incoming stock)."""
-    movement = await record_receipt(db, inventory_id, store.id, data, membership.user_id)
+    movement = await record_receipt(
+        db, inventory_id, store.id, data, membership.user_id
+    )
     await db.commit()
     return movement
 

--- a/app/store_inventory/routes.py
+++ b/app/store_inventory/routes.py
@@ -140,7 +140,7 @@ async def record_inventory_receipt(
     membership: OrgMembership = Depends(get_current_org_membership),
 ) -> InventoryMovement:
     """Record an inventory receipt (incoming stock)."""
-    movement = await record_receipt(db, inventory_id, data, membership.user_id)
+    movement = await record_receipt(db, inventory_id, store.id, data, membership.user_id)
     await db.commit()
     return movement
 
@@ -154,6 +154,6 @@ async def record_inventory_sale(
     membership: OrgMembership = Depends(get_current_org_membership),
 ) -> InventoryMovement:
     """Record an inventory sale (outgoing stock)."""
-    movement = await record_sale(db, inventory_id, data, membership.user_id)
+    movement = await record_sale(db, inventory_id, store.id, data, membership.user_id)
     await db.commit()
     return movement

--- a/app/store_inventory/schemas.py
+++ b/app/store_inventory/schemas.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 from decimal import Decimal
+from enum import Enum as PyEnum
 
 from pydantic import BaseModel, Field
 
@@ -59,3 +60,48 @@ class PaginatedInventoryResponse(BaseModel):
     total: int
     page: int
     page_size: int
+
+
+# ── Movement schemas ──────────────────────────────────────────────────────────
+
+
+class MovementTypeEnum(str, PyEnum):
+    """Movement type for API responses."""
+
+    RECEIPT = "receipt"
+    SALE = "sale"
+
+
+class RecordReceiptRequest(BaseModel):
+    """Request to record an inventory receipt."""
+
+    quantity: int = Field(..., gt=0, description="Quantity received")
+    unit_cost: Decimal | None = Field(None, description="Unit cost per item")
+    reference_number: str | None = Field(None, max_length=100)
+    notes: str | None = Field(None, description="Receipt notes")
+
+
+class RecordSaleRequest(BaseModel):
+    """Request to record an inventory sale."""
+
+    quantity: int = Field(..., gt=0, description="Quantity sold")
+    unit_price: Decimal | None = Field(None, description="Unit price per item")
+    reference_number: str | None = Field(None, max_length=100)
+    notes: str | None = Field(None, description="Sale notes")
+
+
+class MovementRead(BaseModel):
+    """Schema for reading inventory movement records."""
+
+    id: uuid.UUID
+    store_inventory_id: uuid.UUID
+    movement_type: MovementTypeEnum
+    quantity: int
+    unit_cost: Decimal | None
+    unit_price: Decimal | None
+    reference_number: str | None
+    notes: str | None
+    performed_by_user_id: uuid.UUID
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/app/store_inventory/service.py
+++ b/app/store_inventory/service.py
@@ -242,19 +242,23 @@ async def delete_entry(
 async def record_receipt(
     db: AsyncSession,
     inventory_id: uuid.UUID,
+    store_id: uuid.UUID,
     data: "RecordReceiptRequest",
     user_id: uuid.UUID,
 ) -> InventoryMovement:
     """
     Record an inventory receipt and increment the stored quantity.
 
-    Raises NotFound if the inventory entry does not exist.
+    Raises NotFound if the inventory entry does not exist or does not belong
+    to the given store.
     """
-    stmt = select(StoreInventory).where(StoreInventory.id == inventory_id)
+    stmt = select(StoreInventory).where(
+        and_(StoreInventory.id == inventory_id, StoreInventory.store_id == store_id)
+    )
     result = await db.execute(stmt)
     inventory = result.scalars().first()
     if not inventory:
-        raise NotFound(f"Inventory entry {inventory_id} not found")
+        raise NotFound(f"Inventory entry {inventory_id} not found in store {store_id}")
 
     movement = InventoryMovement(
         store_inventory_id=inventory_id,
@@ -277,20 +281,30 @@ async def record_receipt(
 async def record_sale(
     db: AsyncSession,
     inventory_id: uuid.UUID,
+    store_id: uuid.UUID,
     data: "RecordSaleRequest",
     user_id: uuid.UUID,
 ) -> InventoryMovement:
     """
     Record an inventory sale and decrement the stored quantity.
 
-    Raises NotFound if the inventory entry does not exist.
+    Raises NotFound if the inventory entry does not exist or does not belong
+    to the given store.
     Raises AppError(400) if the sale quantity exceeds available stock.
+
+    Uses SELECT … FOR UPDATE to lock the row and prevent concurrent oversells.
     """
-    stmt = select(StoreInventory).where(StoreInventory.id == inventory_id)
+    stmt = (
+        select(StoreInventory)
+        .where(
+            and_(StoreInventory.id == inventory_id, StoreInventory.store_id == store_id)
+        )
+        .with_for_update()
+    )
     result = await db.execute(stmt)
     inventory = result.scalars().first()
     if not inventory:
-        raise NotFound(f"Inventory entry {inventory_id} not found")
+        raise NotFound(f"Inventory entry {inventory_id} not found in store {store_id}")
 
     if inventory.quantity < data.quantity:
         raise AppError(

--- a/app/store_inventory/service.py
+++ b/app/store_inventory/service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.exc import IntegrityError
@@ -14,6 +15,9 @@ from app.core.exceptions import AppError, NotFound
 from app.models.inventory_movement import InventoryMovement, MovementType
 from app.models.product import Product
 from app.models.store_inventory import StoreInventory
+
+if TYPE_CHECKING:
+    from app.store_inventory.schemas import RecordReceiptRequest, RecordSaleRequest
 
 
 async def add_product(

--- a/app/store_inventory/service.py
+++ b/app/store_inventory/service.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.exceptions import AppError, NotFound
+from app.models.inventory_movement import InventoryMovement, MovementType
 from app.models.product import Product
 from app.models.store_inventory import StoreInventory
 
@@ -229,3 +230,82 @@ async def delete_entry(
     entry = await get_entry(db, entry_id=entry_id, store_id=store_id)
     await db.delete(entry)
     await db.flush()
+
+
+# ── Inventory movements ───────────────────────────────────────────────────────
+
+
+async def record_receipt(
+    db: AsyncSession,
+    inventory_id: uuid.UUID,
+    data: "RecordReceiptRequest",
+    user_id: uuid.UUID,
+) -> InventoryMovement:
+    """
+    Record an inventory receipt and increment the stored quantity.
+
+    Raises NotFound if the inventory entry does not exist.
+    """
+    stmt = select(StoreInventory).where(StoreInventory.id == inventory_id)
+    result = await db.execute(stmt)
+    inventory = result.scalars().first()
+    if not inventory:
+        raise NotFound(f"Inventory entry {inventory_id} not found")
+
+    movement = InventoryMovement(
+        store_inventory_id=inventory_id,
+        movement_type=MovementType.RECEIPT,
+        quantity=data.quantity,
+        unit_cost=data.unit_cost,
+        reference_number=data.reference_number,
+        notes=data.notes,
+        performed_by_user_id=user_id,
+    )
+    db.add(movement)
+
+    inventory.quantity += data.quantity
+
+    await db.flush()
+    await db.refresh(movement)
+    return movement
+
+
+async def record_sale(
+    db: AsyncSession,
+    inventory_id: uuid.UUID,
+    data: "RecordSaleRequest",
+    user_id: uuid.UUID,
+) -> InventoryMovement:
+    """
+    Record an inventory sale and decrement the stored quantity.
+
+    Raises NotFound if the inventory entry does not exist.
+    Raises AppError(400) if the sale quantity exceeds available stock.
+    """
+    stmt = select(StoreInventory).where(StoreInventory.id == inventory_id)
+    result = await db.execute(stmt)
+    inventory = result.scalars().first()
+    if not inventory:
+        raise NotFound(f"Inventory entry {inventory_id} not found")
+
+    if inventory.quantity < data.quantity:
+        raise AppError(
+            f"Insufficient stock: {inventory.quantity} available, {data.quantity} requested"
+        )
+
+    movement = InventoryMovement(
+        store_inventory_id=inventory_id,
+        movement_type=MovementType.SALE,
+        quantity=data.quantity,
+        unit_price=data.unit_price,
+        reference_number=data.reference_number,
+        notes=data.notes,
+        performed_by_user_id=user_id,
+    )
+    db.add(movement)
+
+    inventory.quantity -= data.quantity
+
+    await db.flush()
+    await db.refresh(movement)
+    return movement

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -19,6 +19,7 @@ Complete reference for every endpoint in the EasyInventory API. All routes retur
 - [Product–Supplier Links](#productsupplier-links)
 - [Stores](#stores)
 - [Store Inventory](#store-inventory)
+- [Inventory Movements](#inventory-movements)
 - [Layout Versions](#layout-versions)
 - [Zones](#zones)
 - [Admin: Organizations](#admin-organizations)
@@ -821,6 +822,114 @@ Removes a product from the store's inventory.
 **Errors:**
 - `403` — Caller is not the org owner.
 - `404` — Entry not found for this store.
+- `404` — Store not found in the current org.
+
+---
+
+## Inventory Movements
+
+Inventory movements record every stock change with a full audit trail. Each movement stores who performed the action, the quantity, optional cost/price, and an optional reference number. Two movement types are supported:
+
+| Type | Effect | Endpoint |
+|---|---|---|
+| `receipt` | Increases store quantity | `POST …/receipts` |
+| `sale` | Decreases store quantity (validates no negative stock) | `POST …/sales` |
+
+All movement endpoints are nested under an inventory entry: `/api/stores/{store_id}/inventory/{inventory_id}/receipts` and `/api/stores/{store_id}/inventory/{inventory_id}/sales`.
+
+They require authentication and a valid `X-Org-Id` header, and validate that `store_id` belongs to the caller's organization.
+
+---
+
+### `POST /api/stores/{store_id}/inventory/{inventory_id}/receipts`
+
+Records an incoming stock receipt. Increments the inventory entry's `quantity` by the received amount and creates an `InventoryMovement` record linked to the calling user.
+
+**Auth:** Required — any org member  
+**Request Body**
+
+```json
+{
+  "quantity": 50,
+  "unit_cost": "1.25",
+  "reference_number": "PO-2026-001",
+  "notes": "Spring restock from Fresh Farms"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `quantity` | integer | Yes (> 0) | Number of units received |
+| `unit_cost` | decimal string | No | Per-unit cost paid |
+| `reference_number` | string (≤ 100 chars) | No | Purchase order or delivery reference |
+| `notes` | string | No | Free-text notes |
+
+**Response** `201`
+
+```json
+{
+  "id": "movement-uuid",
+  "store_inventory_id": "entry-uuid",
+  "movement_type": "receipt",
+  "quantity": 50,
+  "unit_cost": "1.25",
+  "unit_price": null,
+  "reference_number": "PO-2026-001",
+  "notes": "Spring restock from Fresh Farms",
+  "performed_by_user_id": "user-uuid",
+  "created_at": "2026-03-31T14:00:00Z"
+}
+```
+
+**Errors:**
+- `404` — Inventory entry not found.
+- `404` — Store not found in the current org.
+
+---
+
+### `POST /api/stores/{store_id}/inventory/{inventory_id}/sales`
+
+Records an outgoing stock sale. Decrements the inventory entry's `quantity` by the sold amount and creates an `InventoryMovement` record linked to the calling user. Rejected if the sale quantity exceeds available stock.
+
+**Auth:** Required — any org member  
+**Request Body**
+
+```json
+{
+  "quantity": 12,
+  "unit_price": "2.99",
+  "reference_number": "INV-2026-042",
+  "notes": "Weekly sale batch"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `quantity` | integer | Yes (> 0) | Number of units sold |
+| `unit_price` | decimal string | No | Per-unit price charged |
+| `reference_number` | string (≤ 100 chars) | No | Invoice or POS reference |
+| `notes` | string | No | Free-text notes |
+
+**Response** `201`
+
+```json
+{
+  "id": "movement-uuid",
+  "store_inventory_id": "entry-uuid",
+  "movement_type": "sale",
+  "quantity": 12,
+  "unit_cost": null,
+  "unit_price": "2.99",
+  "reference_number": "INV-2026-042",
+  "notes": "Weekly sale batch",
+  "performed_by_user_id": "user-uuid",
+  "created_at": "2026-03-31T14:05:00Z"
+}
+```
+
+**Errors:**
+- `400` — Insufficient stock (sale quantity exceeds `quantity` on the inventory entry).
+- `404` — Inventory entry not found.
 - `404` — Store not found in the current org.
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,6 +78,11 @@ easyinventory-api/
 │   │   ├── schemas.py           #   ZoneCreate / ZoneUpdate / ZoneRead schemas
 │   │   └── service.py           #   Zone data access (create, list, get, update, delete)
 │   │
+│   ├── store_inventory/         # Store inventory domain
+│   │   ├── routes.py            #   Inventory CRUD + receipt/sale movement endpoints (store-scoped)
+│   │   ├── schemas.py           #   StoreInventory schemas + MovementRead / RecordReceiptRequest / RecordSaleRequest
+│   │   └── service.py           #   Inventory data access + record_receipt / record_sale (quantity validated)
+│   │
 │   ├── suppliers/               # Suppliers domain
 │   │   ├── routes.py            #   Supplier CRUD endpoints
 │   │   ├── schemas.py           #   Supplier Pydantic schemas
@@ -107,6 +112,7 @@ easyinventory-api/
 │       ├── store.py             #   Store (org-scoped, is_active, updated_at)
 │       ├── layout_version.py    #   LayoutVersion (store-scoped, version_number, rows, cols, is_active)
 │       ├── store_inventory.py   #   StoreInventory (store + product link, quantity, unit_price, low-stock threshold)
+│       ├── inventory_movement.py #  InventoryMovement (audit trail of receipts/sales; MovementType enum)
 │       ├── zone.py              #   Zone (layout-version-scoped, name, color, cells JSON)
 │       └── fixture.py           #   Fixture (layout-version-scoped, product reference, type, cell position)
 │
@@ -453,20 +459,27 @@ All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which
 ┌──────────┐     ┌───────────────┐     ┌──────────────┐
 │   User   │────<│ OrgMembership │>────│ Organization │
 └──────────┘     └───────────────┘     └──────────────┘
-                                              │
-                      ┌───────────────────────┼───────────────┐
-                      │               │               │       │
-                ┌─────▼────┐   ┌──────▼─────┐   ┌────▼─────┐  │
-                │ Supplier │   │  Product   │   │  Store   │  │
-                └─────┬────┘   └──────┬──┬──┘   └────┬──┬──┘  │
-                      │               │  │            │  │     │
-                      └──────┐ ┌──────┘  └────┐  ┌───┘  │     │
-                      ┌──────▼─▼──────┐   ┌───▼──▼────────┐   │
-                      │ProductSupplier│   │StoreInventory │   │
-                      └───────────────┘   └───────────────┘   │
-                                                               │
-                                               ┌───────────────┘
-                                          ┌────▼──────────┐
+      │                                       │
+      │                   ┌───────────────────┼───────────────┐
+      │                   │               │               │       │
+      │             ┌─────▼────┐   ┌──────▼─────┐   ┌────▼─────┐
+      │             │ Supplier │   │  Product   │   │  Store   │
+      │             └─────┬────┘   └──────┬──┬──┘   └────┬──┬──┘
+      │                   │               │  │            │  │
+      │                   └──────┐ ┌──────┘  └────┐  ┌───┘  │
+      │             ┌────────────▼─▼────────┐  ┌──▼──▼──────────────┐
+      │             │  ProductSupplier      │  │   StoreInventory   │
+      │             └───────────────────────┘  └─────────┬──────────┘
+      │                                                   │
+      └───────────────────────────────────────────────────┤
+                                              ┌────────────▼──────────┐
+                                              │  InventoryMovement    │
+                                              │  (type, qty,          │
+                                              │   unit_cost/price,    │
+                                              │   performed_by_user)  │
+                                              └───────────────────────┘
+
+                                          ┌───────────────┐
                                           │LayoutVersion  │
                                           └────┬──────────┘
                                                │
@@ -485,6 +498,7 @@ All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which
 | `ProductSupplier` | `product_suppliers` | `product_id` (FK), `supplier_id` (FK), `is_active` | → `Supplier` / Unique on `(product_id, supplier_id)` |
 | `Store` | `stores` | `org_id` (FK, CASCADE), `name`, `is_active`, `updated_at` | → `LayoutVersion` (one-to-many), → `StoreInventory` (one-to-many) |
 | `StoreInventory` | `store_inventory` | `store_id` (FK, CASCADE), `product_id` (FK, CASCADE), `quantity`, `unit_price`, `low_stock_threshold`, `updated_at` | → `Store`, → `Product`; unique on `(store_id, product_id)` |
+| `InventoryMovement` | `inventory_movements` | `store_inventory_id` (FK, CASCADE), `movement_type` (enum: `receipt`/`sale`), `quantity`, `unit_cost`, `unit_price`, `reference_number`, `notes`, `performed_by_user_id` (FK, RESTRICT) | → `StoreInventory`, → `User` |
 | `LayoutVersion` | `layout_versions` | `store_id` (FK, CASCADE), `version_number`, `rows`, `cols`, `is_active`, `updated_at` | → `Zone` (one-to-many); unique on `(store_id, version_number)` |
 | `Zone` | `zones` | `layout_version_id` (FK, CASCADE), `name`, `color`, `cells` (JSON), `updated_at` | → `LayoutVersion` |
 
@@ -501,6 +515,8 @@ All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which
 - **Inventory conditional join** — `list_inventory` only joins the `products` table when `search` or `category` predicates are present. For the common unfiltered case the query stays on `store_inventory` alone and a `selectinload` fetches associated product rows efficiently via a separate IN-clause query. This avoids an unnecessary join for every basic list request.
 - **Stable inventory pagination** — The inventory list is ordered by `(created_at, id)`. The secondary `id` sort key ensures deterministic OFFSET/LIMIT pagination when multiple entries share the same `created_at` timestamp (which can happen when items are inserted in the same transaction).
 - **Inventory product contract** — The `product` field on `StoreInventoryRead` is non-optional (`ProductSummary`, not `ProductSummary | None`). The `product_id` FK is `NOT NULL` and `get_entry` always uses `selectinload`, so a missing product would indicate a data integrity failure rather than an expected empty state.
+- **Inventory movements as an append-only audit trail** — `InventoryMovement` rows are never updated or deleted. Every stock change (receipt or sale) creates a new row, giving a complete history of when stock changed, by how much, at what cost/price, with which reference number, and which user initiated it. `performed_by_user_id` uses `ondelete="RESTRICT"` to prevent deleting a user whose movement records exist. `store_inventory_id` uses `ondelete="CASCADE"` so movements are cleaned up with their parent inventory entry.
+- **Sale validation prevents negative stock** — `record_sale` checks `inventory.quantity >= data.quantity` before writing. If insufficient stock is available it raises an `AppError(400)` before any database write occurs, so no partial state is created.
 
 ---
 

--- a/testsv2/conftest.py
+++ b/testsv2/conftest.py
@@ -21,7 +21,7 @@ from collections.abc import AsyncGenerator
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import event
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     create_async_engine,
@@ -62,6 +62,15 @@ async def setup_database():
     yield
     async with test_engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
+        # Reset the Alembic version stamp so the next ``alembic upgrade head``
+        # replays all migrations from scratch instead of only running the
+        # latest one against a now-empty database.
+        await conn.execute(text("DROP TABLE IF EXISTS alembic_version"))
+        # Drop custom Postgres enum types that are not removed by drop_all
+        # (SQLAlchemy only drops tables, not standalone types).  Without this,
+        # the next ``alembic upgrade head`` would fail with
+        # "type already exists" when recreating the enum.
+        await conn.execute(text("DROP TYPE IF EXISTS movement_type"))
     await test_engine.dispose()
 
 

--- a/testsv2/unit/test_movement_service.py
+++ b/testsv2/unit/test_movement_service.py
@@ -170,7 +170,9 @@ async def test_record_receipt_wrong_store_raises_not_found(db: AsyncSession) -> 
     store_b = await create_store(db, org_id=org.id)
     product = await create_product(db, org_id=org.id)
     # inventory belongs to store_a
-    inventory = await create_store_inventory(db, store_id=store_a.id, product_id=product.id)
+    inventory = await create_store_inventory(
+        db, store_id=store_a.id, product_id=product.id
+    )
     user = await create_user(db)
 
     data = RecordReceiptRequest(quantity=5)

--- a/testsv2/unit/test_movement_service.py
+++ b/testsv2/unit/test_movement_service.py
@@ -19,7 +19,6 @@ from testsv2.factories import (
     create_user,
 )
 
-
 # ── record_receipt ────────────────────────────────────────────────────────────
 
 
@@ -28,7 +27,9 @@ async def test_record_receipt_creates_movement(db: AsyncSession) -> None:
     org = await create_org(db)
     store = await create_store(db, org_id=org.id)
     product = await create_product(db, org_id=org.id)
-    inventory = await create_store_inventory(db, store_id=store.id, product_id=product.id)
+    inventory = await create_store_inventory(
+        db, store_id=store.id, product_id=product.id
+    )
     user = await create_user(db)
 
     data = RecordReceiptRequest(quantity=10, unit_cost=Decimal("5.00"))

--- a/testsv2/unit/test_movement_service.py
+++ b/testsv2/unit/test_movement_service.py
@@ -33,7 +33,7 @@ async def test_record_receipt_creates_movement(db: AsyncSession) -> None:
     user = await create_user(db)
 
     data = RecordReceiptRequest(quantity=10, unit_cost=Decimal("5.00"))
-    movement = await record_receipt(db, inventory.id, data, user.id)
+    movement = await record_receipt(db, inventory.id, store.id, data, user.id)
 
     assert movement.id is not None
     assert movement.store_inventory_id == inventory.id
@@ -55,7 +55,7 @@ async def test_record_receipt_increases_quantity(db: AsyncSession) -> None:
     user = await create_user(db)
 
     data = RecordReceiptRequest(quantity=10)
-    await record_receipt(db, inventory.id, data, user.id)
+    await record_receipt(db, inventory.id, store.id, data, user.id)
 
     await db.refresh(inventory)
     assert inventory.quantity == 15.0
@@ -69,7 +69,7 @@ async def test_record_receipt_not_found(db: AsyncSession) -> None:
     data = RecordReceiptRequest(quantity=5)
 
     with pytest.raises(NotFound):
-        await record_receipt(db, uuid4(), data, user.id)
+        await record_receipt(db, uuid4(), uuid4(), data, user.id)
 
 
 # ── record_sale ───────────────────────────────────────────────────────────────
@@ -86,7 +86,7 @@ async def test_record_sale_creates_movement(db: AsyncSession) -> None:
     user = await create_user(db)
 
     data = RecordSaleRequest(quantity=5, unit_price=Decimal("9.99"))
-    movement = await record_sale(db, inventory.id, data, user.id)
+    movement = await record_sale(db, inventory.id, store.id, data, user.id)
 
     assert movement.id is not None
     assert movement.store_inventory_id == inventory.id
@@ -107,7 +107,7 @@ async def test_record_sale_decreases_quantity(db: AsyncSession) -> None:
     user = await create_user(db)
 
     data = RecordSaleRequest(quantity=5)
-    await record_sale(db, inventory.id, data, user.id)
+    await record_sale(db, inventory.id, store.id, data, user.id)
 
     await db.refresh(inventory)
     assert inventory.quantity == 15.0
@@ -126,7 +126,7 @@ async def test_record_sale_insufficient_stock(db: AsyncSession) -> None:
     data = RecordSaleRequest(quantity=10)
 
     with pytest.raises(AppError) as exc_info:
-        await record_sale(db, inventory.id, data, user.id)
+        await record_sale(db, inventory.id, store.id, data, user.id)
 
     assert exc_info.value.status_code == 400
 
@@ -142,7 +142,7 @@ async def test_record_sale_exact_quantity_succeeds(db: AsyncSession) -> None:
     user = await create_user(db)
 
     data = RecordSaleRequest(quantity=10)
-    movement = await record_sale(db, inventory.id, data, user.id)
+    movement = await record_sale(db, inventory.id, store.id, data, user.id)
 
     await db.refresh(inventory)
     assert movement.quantity == 10
@@ -157,4 +157,41 @@ async def test_record_sale_not_found(db: AsyncSession) -> None:
     data = RecordSaleRequest(quantity=1)
 
     with pytest.raises(NotFound):
-        await record_sale(db, uuid4(), data, user.id)
+        await record_sale(db, uuid4(), uuid4(), data, user.id)
+
+
+# ── Cross-store isolation ────────────────────────────────────────────────────
+
+
+async def test_record_receipt_wrong_store_raises_not_found(db: AsyncSession) -> None:
+    """record_receipt raises NotFound when the inventory_id belongs to a different store."""
+    org = await create_org(db)
+    store_a = await create_store(db, org_id=org.id)
+    store_b = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    # inventory belongs to store_a
+    inventory = await create_store_inventory(db, store_id=store_a.id, product_id=product.id)
+    user = await create_user(db)
+
+    data = RecordReceiptRequest(quantity=5)
+    with pytest.raises(NotFound):
+        # passing store_b.id — should be rejected
+        await record_receipt(db, inventory.id, store_b.id, data, user.id)
+
+
+async def test_record_sale_wrong_store_raises_not_found(db: AsyncSession) -> None:
+    """record_sale raises NotFound when the inventory_id belongs to a different store."""
+    org = await create_org(db)
+    store_a = await create_store(db, org_id=org.id)
+    store_b = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    # inventory belongs to store_a with enough stock
+    inventory = await create_store_inventory(
+        db, store_id=store_a.id, product_id=product.id, quantity=20.0
+    )
+    user = await create_user(db)
+
+    data = RecordSaleRequest(quantity=5)
+    with pytest.raises(NotFound):
+        # passing store_b.id — should be rejected
+        await record_sale(db, inventory.id, store_b.id, data, user.id)

--- a/testsv2/unit/test_movement_service.py
+++ b/testsv2/unit/test_movement_service.py
@@ -1,0 +1,159 @@
+"""
+Unit tests for inventory movement service functions (record_receipt, record_sale).
+Uses the real DB with per-test transaction rollback — no HTTP layer.
+"""
+
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import AppError, NotFound
+from app.store_inventory.schemas import RecordReceiptRequest, RecordSaleRequest
+from app.store_inventory.service import record_receipt, record_sale
+from testsv2.factories import (
+    create_org,
+    create_product,
+    create_store,
+    create_store_inventory,
+    create_user,
+)
+
+
+# ── record_receipt ────────────────────────────────────────────────────────────
+
+
+async def test_record_receipt_creates_movement(db: AsyncSession) -> None:
+    """record_receipt returns an InventoryMovement with correct fields."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    inventory = await create_store_inventory(db, store_id=store.id, product_id=product.id)
+    user = await create_user(db)
+
+    data = RecordReceiptRequest(quantity=10, unit_cost=Decimal("5.00"))
+    movement = await record_receipt(db, inventory.id, data, user.id)
+
+    assert movement.id is not None
+    assert movement.store_inventory_id == inventory.id
+    assert movement.movement_type.value == "receipt"
+    assert movement.quantity == 10
+    assert movement.unit_cost == Decimal("5.00")
+    assert movement.performed_by_user_id == user.id
+    assert movement.created_at is not None
+
+
+async def test_record_receipt_increases_quantity(db: AsyncSession) -> None:
+    """record_receipt increments the inventory quantity by the received amount."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    inventory = await create_store_inventory(
+        db, store_id=store.id, product_id=product.id, quantity=5.0
+    )
+    user = await create_user(db)
+
+    data = RecordReceiptRequest(quantity=10)
+    await record_receipt(db, inventory.id, data, user.id)
+
+    await db.refresh(inventory)
+    assert inventory.quantity == 15.0
+
+
+async def test_record_receipt_not_found(db: AsyncSession) -> None:
+    """record_receipt raises NotFound when the inventory entry does not exist."""
+    from uuid import uuid4
+
+    user = await create_user(db)
+    data = RecordReceiptRequest(quantity=5)
+
+    with pytest.raises(NotFound):
+        await record_receipt(db, uuid4(), data, user.id)
+
+
+# ── record_sale ───────────────────────────────────────────────────────────────
+
+
+async def test_record_sale_creates_movement(db: AsyncSession) -> None:
+    """record_sale returns an InventoryMovement with correct fields."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    inventory = await create_store_inventory(
+        db, store_id=store.id, product_id=product.id, quantity=20.0
+    )
+    user = await create_user(db)
+
+    data = RecordSaleRequest(quantity=5, unit_price=Decimal("9.99"))
+    movement = await record_sale(db, inventory.id, data, user.id)
+
+    assert movement.id is not None
+    assert movement.store_inventory_id == inventory.id
+    assert movement.movement_type.value == "sale"
+    assert movement.quantity == 5
+    assert movement.unit_price == Decimal("9.99")
+    assert movement.performed_by_user_id == user.id
+
+
+async def test_record_sale_decreases_quantity(db: AsyncSession) -> None:
+    """record_sale decrements the inventory quantity by the sold amount."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    inventory = await create_store_inventory(
+        db, store_id=store.id, product_id=product.id, quantity=20.0
+    )
+    user = await create_user(db)
+
+    data = RecordSaleRequest(quantity=5)
+    await record_sale(db, inventory.id, data, user.id)
+
+    await db.refresh(inventory)
+    assert inventory.quantity == 15.0
+
+
+async def test_record_sale_insufficient_stock(db: AsyncSession) -> None:
+    """record_sale raises AppError when requested quantity exceeds available stock."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    inventory = await create_store_inventory(
+        db, store_id=store.id, product_id=product.id, quantity=5.0
+    )
+    user = await create_user(db)
+
+    data = RecordSaleRequest(quantity=10)
+
+    with pytest.raises(AppError) as exc_info:
+        await record_sale(db, inventory.id, data, user.id)
+
+    assert exc_info.value.status_code == 400
+
+
+async def test_record_sale_exact_quantity_succeeds(db: AsyncSession) -> None:
+    """record_sale succeeds when selling exactly the available quantity."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    inventory = await create_store_inventory(
+        db, store_id=store.id, product_id=product.id, quantity=10.0
+    )
+    user = await create_user(db)
+
+    data = RecordSaleRequest(quantity=10)
+    movement = await record_sale(db, inventory.id, data, user.id)
+
+    await db.refresh(inventory)
+    assert movement.quantity == 10
+    assert inventory.quantity == 0.0
+
+
+async def test_record_sale_not_found(db: AsyncSession) -> None:
+    """record_sale raises NotFound when the inventory entry does not exist."""
+    from uuid import uuid4
+
+    user = await create_user(db)
+    data = RecordSaleRequest(quantity=1)
+
+    with pytest.raises(NotFound):
+        await record_sale(db, uuid4(), data, user.id)


### PR DESCRIPTION
## What
Implements inventory movement recording (BE-04). Adds an `InventoryMovement` model and
two new endpoints that create an auditable record of every stock change:

- `POST /api/stores/{store_id}/inventory/{inventory_id}/receipts` — records incoming stock, increments quantity
- `POST /api/stores/{store_id}/inventory/{inventory_id}/sales` — records outgoing stock, decrements quantity with negative-stock validation

Each movement captures the quantity, optional unit cost/price, optional reference number,
free-text notes, and the user who performed the action.

## Why
Closes BE-04. Inventory quantities need a durable audit trail so the business can reconcile
stock levels, track costs, and investigate discrepancies. Direct `PATCH quantity` edits
(BE-03) remain available for corrections, but all normal stock flow should go through
movements going forward.

Depends on BE-02 (products) and BE-03 (store inventory).

## How to test
1. Start the stack: `make up`
2. Run migrations: `make migrate`
3. Seed data: the bootstrap seeder creates a store with inventory entries
4. Hit the endpoints via Swagger at `http://localhost:8000/docs` → **store-inventory** tag

**Record a receipt:**
```http
POST /api/stores/{store_id}/inventory/{inventory_id}/receipts
Authorization: Bearer <token>
X-Org-Id: <org_id>
Content-Type: application/json

{ "quantity": 50, "unit_cost": "1.25", "reference_number": "PO-2026-001" }
```

**Record a sale (happy path):**
```http
POST /api/stores/{store_id}/inventory/{inventory_id}/sales
Authorization: Bearer <token>
X-Org-Id: <org_id>
Content-Type: application/json

{ "quantity": 10, "unit_price": "2.99" }
```

**Verify insufficient-stock rejection:** send a sale with `quantity` greater than the
current inventory quantity — expect `400` with `"Insufficient stock: …"`.

**Run the unit tests:** `make test-v2 -k test_movement`

## Checklist
- [x] `make test` passes
- [x] `make lint` passes (black + mypy)
- [x] No hardcoded secrets or credentials
- [ ] New env vars added to .env.example  *(no new env vars)*
- [ ] README updated if needed  *(no README changes required)*
