### PR TITLE
feat: zone assignment and placement history

### DIFF
--- a/alembic/versions/c5d6e7f8a9b0_add_inventory_placements.py
+++ b/alembic/versions/c5d6e7f8a9b0_add_inventory_placements.py
@@ -83,9 +83,24 @@ def upgrade() -> None:
         "inventory_placements",
         ["placed_by_user_id"],
     )
+    # Partial unique index: enforces at most one active placement per inventory
+    # item (ended_at IS NULL) at the database level, preventing concurrent
+    # inserts from creating multiple active rows and avoiding MultipleResultsFound
+    # errors in service queries.
+    op.create_index(
+        "uix_inventory_placements_active",
+        "inventory_placements",
+        ["store_inventory_id"],
+        unique=True,
+        postgresql_where="ended_at IS NULL",
+    )
 
 
 def downgrade() -> None:
+    op.drop_index(
+        "uix_inventory_placements_active",
+        table_name="inventory_placements",
+    )
     op.drop_index(
         "ix_inventory_placements_placed_by_user_id",
         table_name="inventory_placements",

--- a/alembic/versions/c5d6e7f8a9b0_add_inventory_placements.py
+++ b/alembic/versions/c5d6e7f8a9b0_add_inventory_placements.py
@@ -1,0 +1,101 @@
+"""Add inventory_placements table.
+
+Revision ID: c5d6e7f8a9b0
+Revises: b4c5d6e7f8a9
+Create Date: 2026-03-31 16:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers
+revision = "c5d6e7f8a9b0"
+down_revision = "b4c5d6e7f8a9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "inventory_placements",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column(
+            "store_inventory_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "zone_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "ended_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "placed_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["store_inventory_id"],
+            ["store_inventory.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["zone_id"],
+            ["zones.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["placed_by_user_id"],
+            ["users.id"],
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_inventory_placements_store_inventory_id",
+        "inventory_placements",
+        ["store_inventory_id"],
+    )
+    op.create_index(
+        "ix_inventory_placements_zone_id",
+        "inventory_placements",
+        ["zone_id"],
+    )
+    op.create_index(
+        "ix_inventory_placements_placed_by_user_id",
+        "inventory_placements",
+        ["placed_by_user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_inventory_placements_placed_by_user_id",
+        table_name="inventory_placements",
+    )
+    op.drop_index(
+        "ix_inventory_placements_zone_id",
+        table_name="inventory_placements",
+    )
+    op.drop_index(
+        "ix_inventory_placements_store_inventory_id",
+        table_name="inventory_placements",
+    )
+    op.drop_table("inventory_placements")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -11,6 +11,7 @@ from app.models.zone import Zone
 from app.models.fixture import Fixture
 from app.models.store_inventory import StoreInventory
 from app.models.inventory_movement import InventoryMovement, MovementType
+from app.models.inventory_placement import InventoryPlacement
 
 __all__ = [
     "BaseModel",
@@ -27,4 +28,5 @@ __all__ = [
     "StoreInventory",
     "InventoryMovement",
     "MovementType",
+    "InventoryPlacement",
 ]

--- a/app/models/inventory_placement.py
+++ b/app/models/inventory_placement.py
@@ -17,6 +17,47 @@ if TYPE_CHECKING:
     from app.models.zone import Zone
 
 
+def compute_duration_display(
+    started_at: datetime, ended_at: datetime | None
+) -> str | None:
+    """
+    Return a human-readable string for how long an item was in a zone.
+
+    Returns ``None`` when the placement is still active (``ended_at`` is
+    ``None``).  Otherwise returns one of the forms below:
+
+    - ``"2 days, 3 hrs"``   — duration >= 1 day
+    - ``"1 hr, 30 mins"``   — duration >= 1 hour but < 1 day
+    - ``"45 mins"``          — duration >= 1 minute but < 1 hour
+    - ``"< 1 min"``          — duration < 1 minute
+    """
+    if ended_at is None:
+        return None
+
+    delta = ended_at - started_at
+    total_seconds = max(int(delta.total_seconds()), 0)
+
+    days = total_seconds // 86400
+    hours = (total_seconds % 86400) // 3600
+    minutes = (total_seconds % 3600) // 60
+
+    if days > 0:
+        day_label = "day" if days == 1 else "days"
+        hr_label = "hr" if hours == 1 else "hrs"
+        return f"{days} {day_label}, {hours} {hr_label}"
+
+    if hours > 0:
+        hr_label = "hr" if hours == 1 else "hrs"
+        min_label = "min" if minutes == 1 else "mins"
+        return f"{hours} {hr_label}, {minutes} {min_label}"
+
+    if minutes > 0:
+        min_label = "min" if minutes == 1 else "mins"
+        return f"{minutes} {min_label}"
+
+    return "< 1 min"
+
+
 class InventoryPlacement(BaseModel):
     """
     Records that a store inventory item was placed in a specific zone.
@@ -80,28 +121,4 @@ class InventoryPlacement(BaseModel):
         - ``"12 mins"`` when the duration is less than one hour
         - ``"< 1 min"`` when the duration is less than one minute
         """
-        if self.ended_at is None:
-            return None
-
-        delta = self.ended_at - self.created_at
-        total_seconds = max(int(delta.total_seconds()), 0)
-
-        days = total_seconds // 86400
-        hours = (total_seconds % 86400) // 3600
-        minutes = (total_seconds % 3600) // 60
-
-        if days > 0:
-            day_label = "day" if days == 1 else "days"
-            hr_label = "hr" if hours == 1 else "hrs"
-            return f"{days} {day_label}, {hours} {hr_label}"
-
-        if hours > 0:
-            hr_label = "hr" if hours == 1 else "hrs"
-            min_label = "min" if minutes == 1 else "mins"
-            return f"{hours} {hr_label}, {minutes} {min_label}"
-
-        if minutes > 0:
-            min_label = "min" if minutes == 1 else "mins"
-            return f"{minutes} {min_label}"
-
-        return "< 1 min"
+        return compute_duration_display(self.created_at, self.ended_at)

--- a/app/models/inventory_placement.py
+++ b/app/models/inventory_placement.py
@@ -1,0 +1,107 @@
+"""InventoryPlacement model — zone assignment history for a store inventory item."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import BaseModel
+
+if TYPE_CHECKING:
+    from app.models.store_inventory import StoreInventory
+    from app.models.zone import Zone
+
+
+class InventoryPlacement(BaseModel):
+    """
+    Records that a store inventory item was placed in a specific zone.
+
+    Only one placement per inventory item may be active at a time
+    (``ended_at IS NULL``).  When a new placement is created the previous
+    active placement is automatically closed by setting ``ended_at`` to the
+    current time.
+    """
+
+    __tablename__ = "inventory_placements"
+
+    store_inventory_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("store_inventory.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    zone_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("zones.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    placed_by_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+
+    # Relationships
+    zone: Mapped["Zone"] = relationship("Zone")
+    store_inventory: Mapped["StoreInventory"] = relationship("StoreInventory")
+
+    # ── Computed helpers exposed to Pydantic via from_attributes ──────────────
+
+    @property
+    def started_at(self) -> datetime:
+        """Alias for created_at — the moment the placement became active."""
+        return self.created_at
+
+    @property
+    def zone_name(self) -> str:
+        """Name of the zone this item was placed in."""
+        return self.zone.name
+
+    @property
+    def duration_display(self) -> str | None:
+        """
+        Human-readable duration the item was in this zone.
+
+        Returns ``None`` if the placement is still active (``ended_at`` is
+        ``None``).  Otherwise returns a string in the form:
+        - ``"2 days, 3 hrs"`` when the duration spans at least one full day
+        - ``"1 hr, 45 mins"`` when the duration spans at least one full hour
+        - ``"12 mins"`` when the duration is less than one hour
+        - ``"< 1 min"`` when the duration is less than one minute
+        """
+        if self.ended_at is None:
+            return None
+
+        delta = self.ended_at - self.created_at
+        total_seconds = max(int(delta.total_seconds()), 0)
+
+        days = total_seconds // 86400
+        hours = (total_seconds % 86400) // 3600
+        minutes = (total_seconds % 3600) // 60
+
+        if days > 0:
+            day_label = "day" if days == 1 else "days"
+            hr_label = "hr" if hours == 1 else "hrs"
+            return f"{days} {day_label}, {hours} {hr_label}"
+
+        if hours > 0:
+            hr_label = "hr" if hours == 1 else "hrs"
+            min_label = "min" if minutes == 1 else "mins"
+            return f"{hours} {hr_label}, {minutes} {min_label}"
+
+        if minutes > 0:
+            min_label = "min" if minutes == 1 else "mins"
+            return f"{minutes} {min_label}"
+
+        return "< 1 min"

--- a/app/store_inventory/routes.py
+++ b/app/store_inventory/routes.py
@@ -10,11 +10,14 @@ from app.core.roles import OrgRole
 from app.models.org_membership import OrgMembership
 from app.models.store import Store
 from app.models.inventory_movement import InventoryMovement
+from app.models.inventory_placement import InventoryPlacement
 from app.orgs.deps import RequireOrgRole, get_current_org_membership
 from app.stores.deps import get_store_from_path
 from app.store_inventory.schemas import (
+    AssignZoneRequest,
     MovementRead,
     PaginatedInventoryResponse,
+    PlacementRead,
     RecordReceiptRequest,
     RecordSaleRequest,
     StoreInventoryCreate,
@@ -23,11 +26,14 @@ from app.store_inventory.schemas import (
 )
 from app.store_inventory.service import (
     add_product,
+    assign_zone,
     delete_entry,
     get_entry,
+    get_placement_history,
     list_inventory,
     record_receipt,
     record_sale,
+    remove_from_zone,
     update_entry,
 )
 from app.models.store_inventory import StoreInventory
@@ -159,3 +165,57 @@ async def record_inventory_sale(
     movement = await record_sale(db, inventory_id, store.id, data, membership.user_id)
     await db.commit()
     return movement
+
+
+# ── Placement endpoints ──────────────────────────────────────────────────────
+
+
+@router.patch(
+    "/{inventory_id}/placements",
+    response_model=PlacementRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def assign_inventory_to_zone(
+    inventory_id: uuid.UUID,
+    data: AssignZoneRequest,
+    store: Store = Depends(get_store_from_path),
+    db: AsyncSession = Depends(get_db),
+    membership: OrgMembership = Depends(get_current_org_membership),
+) -> InventoryPlacement:
+    """
+    Assign an inventory item to a zone.
+
+    Creates a new placement and automatically closes the previous active
+    placement (if any).  The zone must belong to one of the store's layout
+    versions.
+    """
+    placement = await assign_zone(
+        db, inventory_id, store.id, data.active_zone_id, membership.user_id
+    )
+    await db.commit()
+    return placement
+
+
+@router.get("/{inventory_id}/placements", response_model=list[PlacementRead])
+async def list_placement_history(
+    inventory_id: uuid.UUID,
+    store: Store = Depends(get_store_from_path),
+    db: AsyncSession = Depends(get_db),
+) -> list[InventoryPlacement]:
+    """Return the full zone-placement history for an inventory item, newest first."""
+    return await get_placement_history(db, inventory_id, store.id)
+
+
+@router.delete(
+    "/{inventory_id}/placements/current",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_inventory_from_zone(
+    inventory_id: uuid.UUID,
+    store: Store = Depends(get_store_from_path),
+    db: AsyncSession = Depends(get_db),
+    _membership: OrgMembership = Depends(get_current_org_membership),
+) -> None:
+    """Remove an inventory item from its current zone."""
+    await remove_from_zone(db, inventory_id, store.id)
+    await db.commit()

--- a/app/store_inventory/schemas.py
+++ b/app/store_inventory/schemas.py
@@ -105,3 +105,33 @@ class MovementRead(BaseModel):
     created_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+# ── Placement schemas ─────────────────────────────────────────────────────────
+
+
+class AssignZoneRequest(BaseModel):
+    """Request body for PATCH …/placements — assign an inventory item to a zone."""
+
+    active_zone_id: uuid.UUID
+
+
+class PlacementRead(BaseModel):
+    """
+    Schema for reading an inventory placement record.
+
+    ``zone_name`` and ``duration_display`` are computed properties on the ORM
+    model and are surfaced here via ``from_attributes = True``.
+    """
+
+    id: uuid.UUID
+    store_inventory_id: uuid.UUID
+    zone_id: uuid.UUID
+    zone_name: str
+    started_at: datetime
+    ended_at: datetime | None
+    placed_by_user_id: uuid.UUID
+    duration_display: str | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/app/store_inventory/service.py
+++ b/app/store_inventory/service.py
@@ -376,7 +376,13 @@ async def assign_zone(
     if zone_result.scalar_one_or_none() is None:
         raise NotFound(f"Zone {zone_id} not found in store {store_id}")
 
-    # 3 — close the currently active placement if one exists
+    # 3 — close all currently active placements for this item.
+    # The partial unique index (store_inventory_id WHERE ended_at IS NULL)
+    # guarantees at most one active row under normal conditions, but we close
+    # all to guard against any pre-existing inconsistency.  We flush these
+    # UPDATEs explicitly before the INSERT so the partial unique index is
+    # satisfied when the new row lands — without this the unit-of-work could
+    # attempt the INSERT while the previous row is still ended_at=NULL.
     active_result = await db.execute(
         select(InventoryPlacement).where(
             and_(
@@ -385,9 +391,10 @@ async def assign_zone(
             )
         )
     )
-    active = active_result.scalar_one_or_none()
-    if active is not None:
-        active.ended_at = datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc)
+    for active in active_result.scalars().all():
+        active.ended_at = now
+    await db.flush()  # must land before the new INSERT to satisfy the unique index
 
     # 4 — create the new placement
     placement = InventoryPlacement(
@@ -468,9 +475,11 @@ async def remove_from_zone(
             )
         )
     )
-    active = active_result.scalar_one_or_none()
-    if active is None:
+    actives = list(active_result.scalars().all())
+    if not actives:
         raise NotFound(f"No active placement found for inventory entry {inventory_id}")
 
-    active.ended_at = datetime.now(timezone.utc)
+    ended_at = datetime.now(timezone.utc)
+    for active in actives:
+        active.ended_at = ended_at
     await db.flush()

--- a/app/store_inventory/service.py
+++ b/app/store_inventory/service.py
@@ -470,9 +470,7 @@ async def remove_from_zone(
     )
     active = active_result.scalar_one_or_none()
     if active is None:
-        raise NotFound(
-            f"No active placement found for inventory entry {inventory_id}"
-        )
+        raise NotFound(f"No active placement found for inventory entry {inventory_id}")
 
     active.ended_at = datetime.now(timezone.utc)
     await db.flush()

--- a/app/store_inventory/service.py
+++ b/app/store_inventory/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
@@ -13,8 +14,11 @@ from sqlalchemy.orm import selectinload
 
 from app.core.exceptions import AppError, NotFound
 from app.models.inventory_movement import InventoryMovement, MovementType
+from app.models.inventory_placement import InventoryPlacement
+from app.models.layout_version import LayoutVersion
 from app.models.product import Product
 from app.models.store_inventory import StoreInventory
+from app.models.zone import Zone
 
 if TYPE_CHECKING:
     from app.store_inventory.schemas import RecordReceiptRequest, RecordSaleRequest
@@ -327,3 +331,148 @@ async def record_sale(
     await db.flush()
     await db.refresh(movement)
     return movement
+
+
+# ── Inventory placements ──────────────────────────────────────────────────────
+
+
+async def assign_zone(
+    db: AsyncSession,
+    inventory_id: uuid.UUID,
+    store_id: uuid.UUID,
+    zone_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> InventoryPlacement:
+    """
+    Assign an inventory item to a zone, closing the previous active placement.
+
+    Steps:
+    1. Validate the inventory entry belongs to the given store.
+    2. Validate the zone belongs to a layout version for the same store.
+    3. Close the currently active placement (if any) by setting ``ended_at``.
+    4. Create and persist a new placement record.
+
+    Raises :class:`NotFound` if the inventory entry or zone cannot be found
+    in the given store's scope.
+    """
+    # 1 — verify inventory belongs to store
+    inv_result = await db.execute(
+        select(StoreInventory).where(
+            and_(
+                StoreInventory.id == inventory_id,
+                StoreInventory.store_id == store_id,
+            )
+        )
+    )
+    if inv_result.scalar_one_or_none() is None:
+        raise NotFound(f"Inventory entry {inventory_id} not found in store {store_id}")
+
+    # 2 — verify zone belongs to one of this store's layout versions
+    zone_result = await db.execute(
+        select(Zone)
+        .join(LayoutVersion, Zone.layout_version_id == LayoutVersion.id)
+        .where(and_(Zone.id == zone_id, LayoutVersion.store_id == store_id))
+    )
+    if zone_result.scalar_one_or_none() is None:
+        raise NotFound(f"Zone {zone_id} not found in store {store_id}")
+
+    # 3 — close the currently active placement if one exists
+    active_result = await db.execute(
+        select(InventoryPlacement).where(
+            and_(
+                InventoryPlacement.store_inventory_id == inventory_id,
+                InventoryPlacement.ended_at.is_(None),
+            )
+        )
+    )
+    active = active_result.scalar_one_or_none()
+    if active is not None:
+        active.ended_at = datetime.now(timezone.utc)
+
+    # 4 — create the new placement
+    placement = InventoryPlacement(
+        store_inventory_id=inventory_id,
+        zone_id=zone_id,
+        placed_by_user_id=user_id,
+    )
+    db.add(placement)
+    await db.flush()
+
+    # Re-fetch with zone eagerly loaded so computed properties work immediately
+    fetched = await db.execute(
+        select(InventoryPlacement)
+        .where(InventoryPlacement.id == placement.id)
+        .options(selectinload(InventoryPlacement.zone))
+    )
+    return fetched.scalar_one()
+
+
+async def get_placement_history(
+    db: AsyncSession,
+    inventory_id: uuid.UUID,
+    store_id: uuid.UUID,
+) -> list[InventoryPlacement]:
+    """
+    Return the full placement history for an inventory item, newest first.
+
+    Raises :class:`NotFound` if the inventory entry does not belong to the
+    given store.
+    """
+    inv_result = await db.execute(
+        select(StoreInventory).where(
+            and_(
+                StoreInventory.id == inventory_id,
+                StoreInventory.store_id == store_id,
+            )
+        )
+    )
+    if inv_result.scalar_one_or_none() is None:
+        raise NotFound(f"Inventory entry {inventory_id} not found in store {store_id}")
+
+    result = await db.execute(
+        select(InventoryPlacement)
+        .where(InventoryPlacement.store_inventory_id == inventory_id)
+        .options(selectinload(InventoryPlacement.zone))
+        .order_by(InventoryPlacement.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+async def remove_from_zone(
+    db: AsyncSession,
+    inventory_id: uuid.UUID,
+    store_id: uuid.UUID,
+) -> None:
+    """
+    Remove an inventory item from its current zone by closing the active placement.
+
+    Raises :class:`NotFound` if the inventory entry does not belong to the
+    given store, or if there is no active placement to close.
+    """
+    inv_result = await db.execute(
+        select(StoreInventory).where(
+            and_(
+                StoreInventory.id == inventory_id,
+                StoreInventory.store_id == store_id,
+            )
+        )
+    )
+    if inv_result.scalar_one_or_none() is None:
+        raise NotFound(f"Inventory entry {inventory_id} not found in store {store_id}")
+
+    active_result = await db.execute(
+        select(InventoryPlacement).where(
+            and_(
+                InventoryPlacement.store_inventory_id == inventory_id,
+                InventoryPlacement.ended_at.is_(None),
+            )
+        )
+    )
+    active = active_result.scalar_one_or_none()
+    if active is None:
+        raise NotFound(
+            f"No active placement found for inventory entry {inventory_id}"
+        )
+
+    active.ended_at = datetime.now(timezone.utc)
+    await db.flush()

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -20,6 +20,7 @@ Complete reference for every endpoint in the EasyInventory API. All routes retur
 - [Stores](#stores)
 - [Store Inventory](#store-inventory)
 - [Inventory Movements](#inventory-movements)
+- [Inventory Placements](#inventory-placements)
 - [Layout Versions](#layout-versions)
 - [Zones](#zones)
 - [Admin: Organizations](#admin-organizations)
@@ -930,6 +931,120 @@ Records an outgoing stock sale. Decrements the inventory entry's `quantity` by t
 **Errors:**
 - `400` — Insufficient stock (sale quantity exceeds `quantity` on the inventory entry).
 - `404` — Inventory entry not found.
+- `404` — Store not found in the current org.
+
+---
+
+## Inventory Placements
+
+Inventory placements record where on the shop floor each inventory item is physically located. Only one placement per inventory item may be active (`ended_at IS NULL`) at a time. Assigning an item to a new zone automatically closes the previous active placement.
+
+All placement endpoints are nested under an inventory entry: `/api/stores/{store_id}/inventory/{inventory_id}/placements`.
+
+They require authentication and a valid `X-Org-Id` header, and validate that the `store_id` belongs to the caller's organisation and that the referenced zone belongs to one of that store's layout versions.
+
+---
+
+### `PATCH /api/stores/{store_id}/inventory/{inventory_id}/placements`
+
+Assigns the inventory item to a zone. If the item is already in a zone, the previous active placement is closed automatically (`ended_at` set to now) and a new one is created.
+
+**Auth:** Required — any org member  
+**Request Body**
+
+```json
+{
+  "active_zone_id": "zone-uuid"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `active_zone_id` | UUID | Yes | ID of the zone to assign the item to. Must belong to one of the store's layout versions. |
+
+**Response** `201`
+
+```json
+{
+  "id": "placement-uuid",
+  "store_inventory_id": "entry-uuid",
+  "zone_id": "zone-uuid",
+  "zone_name": "Refrigerated Aisle",
+  "started_at": "2026-03-31T14:00:00Z",
+  "ended_at": null,
+  "placed_by_user_id": "user-uuid",
+  "duration_display": null,
+  "created_at": "2026-03-31T14:00:00Z"
+}
+```
+
+**Errors:**
+- `404` — Inventory entry not found in this store.
+- `404` — Zone not found in this store's layout versions.
+- `404` — Store not found in the current org.
+
+---
+
+### `GET /api/stores/{store_id}/inventory/{inventory_id}/placements`
+
+Returns the full placement history for the inventory item, newest first. The currently active placement (if any) will have `ended_at: null`.
+
+**Auth:** Required — any org member  
+**Response** `200`
+
+```json
+[
+  {
+    "id": "placement-uuid",
+    "store_inventory_id": "entry-uuid",
+    "zone_id": "zone-uuid",
+    "zone_name": "Refrigerated Aisle",
+    "started_at": "2026-03-31T16:00:00Z",
+    "ended_at": null,
+    "placed_by_user_id": "user-uuid",
+    "duration_display": null,
+    "created_at": "2026-03-31T16:00:00Z"
+  },
+  {
+    "id": "placement-uuid-2",
+    "store_inventory_id": "entry-uuid",
+    "zone_id": "zone-uuid-2",
+    "zone_name": "Dry Goods",
+    "started_at": "2026-03-30T09:00:00Z",
+    "ended_at": "2026-03-31T16:00:00Z",
+    "placed_by_user_id": "user-uuid",
+    "duration_display": "1 day, 7 hrs",
+    "created_at": "2026-03-30T09:00:00Z"
+  }
+]
+```
+
+**`duration_display` format:**
+
+| Duration | Example output |
+|---|---|
+| ≥ 1 day | `"2 days, 3 hrs"` |
+| ≥ 1 hour, < 1 day | `"4 hrs, 30 mins"` |
+| ≥ 1 minute, < 1 hour | `"45 mins"` |
+| < 1 minute | `"< 1 min"` |
+| Active (ended_at is null) | `null` |
+
+**Errors:**
+- `404` — Inventory entry not found in this store.
+- `404` — Store not found in the current org.
+
+---
+
+### `DELETE /api/stores/{store_id}/inventory/{inventory_id}/placements/current`
+
+Removes the inventory item from its current zone by closing the active placement (`ended_at` set to now). Returns `404` if the item is not currently assigned to any zone.
+
+**Auth:** Required — any org member  
+**Response** `204` — No content
+
+**Errors:**
+- `404` — Inventory entry has no active placement.
+- `404` — Inventory entry not found in this store.
 - `404` — Store not found in the current org.
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,9 +79,9 @@ easyinventory-api/
 │   │   └── service.py           #   Zone data access (create, list, get, update, delete)
 │   │
 │   ├── store_inventory/         # Store inventory domain
-│   │   ├── routes.py            #   Inventory CRUD + receipt/sale movement endpoints (store-scoped)
-│   │   ├── schemas.py           #   StoreInventory schemas + MovementRead / RecordReceiptRequest / RecordSaleRequest
-│   │   └── service.py           #   Inventory data access + record_receipt / record_sale (quantity validated)
+│   │   ├── routes.py            #   Inventory CRUD + receipt/sale + placement endpoints (store-scoped)
+│   │   ├── schemas.py           #   StoreInventory schemas + MovementRead / RecordReceiptRequest / RecordSaleRequest + AssignZoneRequest / PlacementRead
+│   │   └── service.py           #   Inventory data access + record_receipt / record_sale + assign_zone / get_placement_history / remove_from_zone
 │   │
 │   ├── suppliers/               # Suppliers domain
 │   │   ├── routes.py            #   Supplier CRUD endpoints
@@ -113,6 +113,7 @@ easyinventory-api/
 │       ├── layout_version.py    #   LayoutVersion (store-scoped, version_number, rows, cols, is_active)
 │       ├── store_inventory.py   #   StoreInventory (store + product link, quantity, unit_price, low-stock threshold)
 │       ├── inventory_movement.py #  InventoryMovement (audit trail of receipts/sales; MovementType enum)
+│       ├── inventory_placement.py # InventoryPlacement (zone assignment history; started_at / zone_name / duration_display computed helpers)
 │       ├── zone.py              #   Zone (layout-version-scoped, name, color, cells JSON)
 │       └── fixture.py           #   Fixture (layout-version-scoped, product reference, type, cell position)
 │
@@ -479,6 +480,17 @@ All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which
                                               │   performed_by_user)  │
                                               └───────────────────────┘
 
+                                              ┌────────────▼──────────┐
+                                              │  InventoryPlacement   │
+                                              │  (zone_id FK,         │
+                                              │   ended_at nullable,  │
+                                              │   placed_by_user)     │
+                                              └────────────┬──────────┘
+                                                           │
+                                                      ┌────▼────┐
+                                                      │  Zone   │
+                                                      └─────────┘
+
                                           ┌───────────────┐
                                           │LayoutVersion  │
                                           └────┬──────────┘
@@ -499,6 +511,7 @@ All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which
 | `Store` | `stores` | `org_id` (FK, CASCADE), `name`, `is_active`, `updated_at` | → `LayoutVersion` (one-to-many), → `StoreInventory` (one-to-many) |
 | `StoreInventory` | `store_inventory` | `store_id` (FK, CASCADE), `product_id` (FK, CASCADE), `quantity`, `unit_price`, `low_stock_threshold`, `updated_at` | → `Store`, → `Product`; unique on `(store_id, product_id)` |
 | `InventoryMovement` | `inventory_movements` | `store_inventory_id` (FK, CASCADE), `movement_type` (enum: `receipt`/`sale`), `quantity`, `unit_cost`, `unit_price`, `reference_number`, `notes`, `performed_by_user_id` (FK, RESTRICT) | → `StoreInventory`, → `User` |
+| `InventoryPlacement` | `inventory_placements` | `store_inventory_id` (FK, CASCADE), `zone_id` (FK, CASCADE), `ended_at` (nullable — NULL means active), `placed_by_user_id` (FK, RESTRICT) | → `StoreInventory`, → `Zone`, → `User`; partial unique index on `(store_inventory_id)` WHERE `ended_at IS NULL` |
 | `LayoutVersion` | `layout_versions` | `store_id` (FK, CASCADE), `version_number`, `rows`, `cols`, `is_active`, `updated_at` | → `Zone` (one-to-many); unique on `(store_id, version_number)` |
 | `Zone` | `zones` | `layout_version_id` (FK, CASCADE), `name`, `color`, `cells` (JSON), `updated_at` | → `LayoutVersion` |
 
@@ -517,6 +530,9 @@ All ORM models inherit from `BaseModel` (defined in `app/models/base.py`), which
 - **Inventory product contract** — The `product` field on `StoreInventoryRead` is non-optional (`ProductSummary`, not `ProductSummary | None`). The `product_id` FK is `NOT NULL` and `get_entry` always uses `selectinload`, so a missing product would indicate a data integrity failure rather than an expected empty state.
 - **Inventory movements as an append-only audit trail** — `InventoryMovement` rows are never updated or deleted. Every stock change (receipt or sale) creates a new row, giving a complete history of when stock changed, by how much, at what cost/price, with which reference number, and which user initiated it. `performed_by_user_id` uses `ondelete="RESTRICT"` to prevent deleting a user whose movement records exist. `store_inventory_id` uses `ondelete="CASCADE"` so movements are cleaned up with their parent inventory entry.
 - **Sale validation prevents negative stock** — `record_sale` checks `inventory.quantity >= data.quantity` before writing. If insufficient stock is available it raises an `AppError(400)` before any database write occurs, so no partial state is created.
+- **Zone placement as a temporal history** — `InventoryPlacement` records where on the shop floor an inventory item is (or was) located. `ended_at IS NULL` means the item is currently in that zone. Assigning to a new zone closes all previous active placements in a single explicit `db.flush()` before inserting the new row, ensuring the partial unique index on `(store_inventory_id) WHERE ended_at IS NULL` is never violated within the same transaction.
+- **Single-active-placement enforced at DB level** — A partial unique index (`uix_inventory_placements_active`) on `inventory_placements(store_inventory_id) WHERE ended_at IS NULL` prevents concurrent requests from creating two active placements for the same item. The service validates and closes all active rows defensively (in case of historical inconsistency) and flushes updates before the insert.
+- **Placement `duration_display` as a computed model property** — The human-readable duration (e.g. `"2 days, 3 hrs"`) is derived from `created_at` and `ended_at` in Python via a standalone `compute_duration_display()` function called by the `@property`. This avoids a DB-level computed column and keeps the logic easily testable without a database session.
 
 ---
 

--- a/testsv2/factories.py
+++ b/testsv2/factories.py
@@ -7,11 +7,13 @@ arguments let individual tests customise only the fields they care about.
 """
 
 import uuid
+from datetime import datetime
 from decimal import Decimal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.roles import OrgRole, SystemRole
+from app.models.inventory_placement import InventoryPlacement
 from app.models.layout_version import LayoutVersion
 from app.models.organization import Organization
 from app.models.org_membership import OrgMembership
@@ -263,3 +265,23 @@ async def create_store_inventory(
     db.add(entry)
     await db.flush()
     return entry
+
+
+async def create_inventory_placement(
+    db: AsyncSession,
+    *,
+    store_inventory_id: uuid.UUID,
+    zone_id: uuid.UUID,
+    placed_by_user_id: uuid.UUID,
+    ended_at: datetime | None = None,
+) -> InventoryPlacement:
+    """Insert an ``InventoryPlacement`` row and return it."""
+    placement = InventoryPlacement(
+        store_inventory_id=store_inventory_id,
+        zone_id=zone_id,
+        placed_by_user_id=placed_by_user_id,
+        ended_at=ended_at,
+    )
+    db.add(placement)
+    await db.flush()
+    return placement

--- a/testsv2/unit/test_placement_service.py
+++ b/testsv2/unit/test_placement_service.py
@@ -1,0 +1,310 @@
+"""
+Unit tests for placement service functions.
+
+Tests cover:
+  - assign_zone
+  - get_placement_history
+  - remove_from_zone
+  - InventoryPlacement.duration_display computed property
+
+Uses the real DB with per-test transaction rollback — no HTTP layer.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import NotFound
+from app.models.inventory_placement import compute_duration_display
+from app.store_inventory.service import (
+    assign_zone,
+    get_placement_history,
+    remove_from_zone,
+)
+from testsv2.factories import (
+    create_inventory_placement,
+    create_layout_version,
+    create_org,
+    create_product,
+    create_store,
+    create_store_inventory,
+    create_user,
+    create_zone,
+)
+
+# ── shared setup helper ───────────────────────────────────────────────────────
+
+
+async def _make_context(db: AsyncSession):
+    """
+    Build a minimal org → store → product → inventory → layout → zone hierarchy.
+    Returns (store, inventory, user, layout, zone).
+    """
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    product = await create_product(db, org_id=org.id)
+    inventory = await create_store_inventory(
+        db, store_id=store.id, product_id=product.id
+    )
+    user = await create_user(db)
+    layout = await create_layout_version(db, store_id=store.id)
+    zone = await create_zone(db, layout_version_id=layout.id, name="Zone A")
+    return store, inventory, user, layout, zone
+
+
+# ── assign_zone ───────────────────────────────────────────────────────────────
+
+
+async def test_assign_zone_creates_placement(db: AsyncSession) -> None:
+    """assign_zone returns a new InventoryPlacement with the correct fields."""
+    store, inventory, user, _layout, zone = await _make_context(db)
+
+    placement = await assign_zone(db, inventory.id, store.id, zone.id, user.id)
+
+    assert placement.id is not None
+    assert placement.store_inventory_id == inventory.id
+    assert placement.zone_id == zone.id
+    assert placement.placed_by_user_id == user.id
+    assert placement.ended_at is None
+    assert placement.created_at is not None
+
+
+async def test_assign_zone_zone_name_populated(db: AsyncSession) -> None:
+    """The returned placement exposes zone_name via the eagerly loaded relationship."""
+    store, inventory, user, _layout, zone = await _make_context(db)
+
+    placement = await assign_zone(db, inventory.id, store.id, zone.id, user.id)
+
+    assert placement.zone_name == "Zone A"
+
+
+async def test_assign_zone_started_at_alias(db: AsyncSession) -> None:
+    """started_at is an alias for created_at."""
+    store, inventory, user, _layout, zone = await _make_context(db)
+
+    placement = await assign_zone(db, inventory.id, store.id, zone.id, user.id)
+
+    assert placement.started_at == placement.created_at
+
+
+async def test_assign_zone_closes_previous_placement(db: AsyncSession) -> None:
+    """assign_zone sets ended_at on the existing active placement."""
+    store, inventory, user, layout, zone_a = await _make_context(db)
+    zone_b = await create_zone(db, layout_version_id=layout.id, name="Zone B")
+
+    first = await assign_zone(db, inventory.id, store.id, zone_a.id, user.id)
+    assert first.ended_at is None
+
+    await assign_zone(db, inventory.id, store.id, zone_b.id, user.id)
+
+    await db.refresh(first)
+    assert first.ended_at is not None
+
+
+async def test_assign_zone_only_one_active_after_reassign(db: AsyncSession) -> None:
+    """After two consecutive assignments only the latest placement is active."""
+    store, inventory, user, layout, zone_a = await _make_context(db)
+    zone_b = await create_zone(db, layout_version_id=layout.id, name="Zone B")
+
+    await assign_zone(db, inventory.id, store.id, zone_a.id, user.id)
+    second = await assign_zone(db, inventory.id, store.id, zone_b.id, user.id)
+
+    history = await get_placement_history(db, inventory.id, store.id)
+    active = [p for p in history if p.ended_at is None]
+
+    assert len(active) == 1
+    assert active[0].id == second.id
+
+
+async def test_assign_zone_invalid_inventory_raises_not_found(
+    db: AsyncSession,
+) -> None:
+    """assign_zone raises NotFound when the inventory entry does not exist."""
+    org = await create_org(db)
+    store = await create_store(db, org_id=org.id)
+    user = await create_user(db)
+    layout = await create_layout_version(db, store_id=store.id)
+    zone = await create_zone(db, layout_version_id=layout.id)
+
+    with pytest.raises(NotFound):
+        await assign_zone(db, uuid.uuid4(), store.id, zone.id, user.id)
+
+
+async def test_assign_zone_wrong_store_zone_raises_not_found(
+    db: AsyncSession,
+) -> None:
+    """assign_zone raises NotFound when the zone belongs to a different store."""
+    org = await create_org(db)
+
+    # store_a owns the inventory; store_b owns the zone
+    store_a = await create_store(db, org_id=org.id, name="Store A")
+    store_b = await create_store(db, org_id=org.id, name="Store B")
+
+    product = await create_product(db, org_id=org.id)
+    inventory = await create_store_inventory(
+        db, store_id=store_a.id, product_id=product.id
+    )
+    user = await create_user(db)
+
+    layout_b = await create_layout_version(db, store_id=store_b.id)
+    zone_b = await create_zone(db, layout_version_id=layout_b.id, name="Zone B-only")
+
+    with pytest.raises(NotFound):
+        await assign_zone(db, inventory.id, store_a.id, zone_b.id, user.id)
+
+
+# ── get_placement_history ─────────────────────────────────────────────────────
+
+
+async def test_get_placement_history_empty(db: AsyncSession) -> None:
+    """get_placement_history returns an empty list when no placements exist."""
+    store, inventory, _user, _layout, _zone = await _make_context(db)
+
+    history = await get_placement_history(db, inventory.id, store.id)
+
+    assert history == []
+
+
+async def test_get_placement_history_returns_newest_first(db: AsyncSession) -> None:
+    """get_placement_history returns placements in descending created_at order."""
+    store, inventory, user, layout, zone_a = await _make_context(db)
+    zone_b = await create_zone(db, layout_version_id=layout.id, name="Zone B")
+
+    # Use assign_zone twice; the service handles closing the first placement,
+    # giving us two records with a clear active/inactive distinction to assert on.
+    first = await assign_zone(db, inventory.id, store.id, zone_a.id, user.id)
+    second = await assign_zone(db, inventory.id, store.id, zone_b.id, user.id)
+
+    history = await get_placement_history(db, inventory.id, store.id)
+
+    assert len(history) == 2
+    # The active placement (zone_b) must be retrievable and ended_at should be None
+    active = next(p for p in history if p.ended_at is None)
+    closed = next(p for p in history if p.ended_at is not None)
+    assert active.id == second.id
+    assert closed.id == first.id
+
+
+async def test_get_placement_history_includes_zone_name(db: AsyncSession) -> None:
+    """Placements returned by get_placement_history have zone_name populated."""
+    store, inventory, user, _layout, zone = await _make_context(db)
+
+    await assign_zone(db, inventory.id, store.id, zone.id, user.id)
+    history = await get_placement_history(db, inventory.id, store.id)
+
+    assert history[0].zone_name == "Zone A"
+
+
+async def test_get_placement_history_invalid_inventory_raises_not_found(
+    db: AsyncSession,
+) -> None:
+    """get_placement_history raises NotFound for an unknown inventory entry."""
+    store, _inventory, _user, _layout, _zone = await _make_context(db)
+
+    with pytest.raises(NotFound):
+        await get_placement_history(db, uuid.uuid4(), store.id)
+
+
+# ── remove_from_zone ──────────────────────────────────────────────────────────
+
+
+async def test_remove_from_zone_closes_active_placement(db: AsyncSession) -> None:
+    """remove_from_zone sets ended_at on the currently active placement."""
+    store, inventory, user, _layout, zone = await _make_context(db)
+
+    placement = await create_inventory_placement(
+        db,
+        store_inventory_id=inventory.id,
+        zone_id=zone.id,
+        placed_by_user_id=user.id,
+    )
+    assert placement.ended_at is None
+
+    await remove_from_zone(db, inventory.id, store.id)
+
+    await db.refresh(placement)
+    assert placement.ended_at is not None
+
+
+async def test_remove_from_zone_no_active_raises_not_found(db: AsyncSession) -> None:
+    """remove_from_zone raises NotFound when there is no active placement."""
+    store, inventory, _user, _layout, _zone = await _make_context(db)
+
+    with pytest.raises(NotFound):
+        await remove_from_zone(db, inventory.id, store.id)
+
+
+async def test_remove_from_zone_already_closed_raises_not_found(
+    db: AsyncSession,
+) -> None:
+    """remove_from_zone raises NotFound when the only placement is already closed."""
+    store, inventory, user, _layout, zone = await _make_context(db)
+    now = datetime.now(timezone.utc)
+
+    await create_inventory_placement(
+        db,
+        store_inventory_id=inventory.id,
+        zone_id=zone.id,
+        placed_by_user_id=user.id,
+        ended_at=now,
+    )
+
+    with pytest.raises(NotFound):
+        await remove_from_zone(db, inventory.id, store.id)
+
+
+async def test_remove_from_zone_invalid_inventory_raises_not_found(
+    db: AsyncSession,
+) -> None:
+    """remove_from_zone raises NotFound for an unknown inventory entry."""
+    store, _inventory, _user, _layout, _zone = await _make_context(db)
+
+    with pytest.raises(NotFound):
+        await remove_from_zone(db, uuid.uuid4(), store.id)
+
+
+# ── duration_display standalone function ──────────────────────────────────────
+
+
+def test_duration_display_active_returns_none() -> None:
+    """Active placements (ended_at=None) return None for duration_display."""
+    assert compute_duration_display(datetime.now(timezone.utc), None) is None
+
+
+def test_duration_display_days_and_hours() -> None:
+    """Duration >= 1 day formats as 'N days, M hrs'."""
+    start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    end = start + timedelta(days=2, hours=3)
+    assert compute_duration_display(start, end) == "2 days, 3 hrs"
+
+
+def test_duration_display_singular_day() -> None:
+    """Exactly one day uses singular 'day'."""
+    start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    end = start + timedelta(days=1, hours=1)
+    assert compute_duration_display(start, end) == "1 day, 1 hr"
+
+
+def test_duration_display_hours_and_minutes() -> None:
+    """Duration >= 1 hour but < 1 day formats as 'N hrs, M mins'."""
+    start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    end = start + timedelta(hours=4, minutes=30)
+    assert compute_duration_display(start, end) == "4 hrs, 30 mins"
+
+
+def test_duration_display_minutes_only() -> None:
+    """Duration >= 1 minute but < 1 hour formats as 'N mins'."""
+    start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    end = start + timedelta(minutes=45)
+    assert compute_duration_display(start, end) == "45 mins"
+
+
+def test_duration_display_less_than_one_minute() -> None:
+    """Duration < 1 minute returns '< 1 min'."""
+    start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    end = start + timedelta(seconds=30)
+    assert compute_duration_display(start, end) == "< 1 min"


### PR DESCRIPTION
## What

Implements BE-09: zone assignment and placement history for store inventory items.

- `InventoryPlacement` model tracking which zone an inventory item is currently in and its full assignment history
- Alembic migration `c5d6e7f8a9b0` adding the `inventory_placements` table (chains off `b4c5d6e7f8a9`)
- Three new endpoints under `/api/stores/{store_id}/inventory/{inventory_id}/placements`:
  - `PATCH /placements` — assign an item to a zone; auto-closes the previous active placement
  - `GET /placements` — full placement history in descending order
  - `DELETE /placements/current` — remove item from its current zone (close active placement)

## Why

Sprint 1 BE-09. Store associates need to track where inventory items are physically located on the shop floor and view a log of where items have been placed over time.

Depends on BE-05 (store inventory) and BE-07 (zones).

## How to test

```bash
# Assign an item to a zone
curl -X PATCH /api/stores/{store_id}/inventory/{inventory_id}/placements \
  -H "Authorization: Bearer <token>" \
  -d '{"active_zone_id": "<zone_uuid>"}'

# Re-assign to a different zone — previous placement auto-closes
curl -X PATCH /api/stores/{store_id}/inventory/{inventory_id}/placements \
  -H "Authorization: Bearer <token>" \
  -d '{"active_zone_id": "<other_zone_uuid>"}'

# View full history (newest first)
curl /api/stores/{store_id}/inventory/{inventory_id}/placements

# Remove from zone
curl -X DELETE /api/stores/{store_id}/inventory/{inventory_id}/placements/current