### PR TITLE
feat: add GET movements history endpoint

### DIFF
--- a/app/store_inventory/routes.py
+++ b/app/store_inventory/routes.py
@@ -31,6 +31,7 @@ from app.store_inventory.service import (
     get_entry,
     get_placement_history,
     list_inventory,
+    list_movements,
     record_receipt,
     record_sale,
     remove_from_zone,
@@ -151,6 +152,16 @@ async def record_inventory_receipt(
     )
     await db.commit()
     return movement
+
+
+@router.get("/{inventory_id}/movements", response_model=list[MovementRead])
+async def list_inventory_movements(
+    inventory_id: uuid.UUID,
+    store: Store = Depends(get_store_from_path),
+    db: AsyncSession = Depends(get_db),
+) -> list[InventoryMovement]:
+    """Return the full stock-movement history for an inventory item, newest first."""
+    return await list_movements(db, inventory_id, store.id)
 
 
 @router.post("/{inventory_id}/sales", response_model=MovementRead, status_code=201)

--- a/app/store_inventory/service.py
+++ b/app/store_inventory/service.py
@@ -333,6 +333,36 @@ async def record_sale(
     return movement
 
 
+async def list_movements(
+    db: AsyncSession,
+    inventory_id: uuid.UUID,
+    store_id: uuid.UUID,
+) -> list[InventoryMovement]:
+    """
+    Return all movement records for an inventory entry, newest first.
+
+    Raises :class:`NotFound` if the inventory entry does not belong to the
+    given store.
+    """
+    inv_result = await db.execute(
+        select(StoreInventory).where(
+            and_(
+                StoreInventory.id == inventory_id,
+                StoreInventory.store_id == store_id,
+            )
+        )
+    )
+    if inv_result.scalar_one_or_none() is None:
+        raise NotFound(f"Inventory entry {inventory_id} not found in store {store_id}")
+
+    result = await db.execute(
+        select(InventoryMovement)
+        .where(InventoryMovement.store_inventory_id == inventory_id)
+        .order_by(InventoryMovement.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
 # ── Inventory placements ──────────────────────────────────────────────────────
 
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -836,7 +836,9 @@ Inventory movements record every stock change with a full audit trail. Each move
 | `receipt` | Increases store quantity | `POST …/receipts` |
 | `sale` | Decreases store quantity (validates no negative stock) | `POST …/sales` |
 
-All movement endpoints are nested under an inventory entry: `/api/stores/{store_id}/inventory/{inventory_id}/receipts` and `/api/stores/{store_id}/inventory/{inventory_id}/sales`.
+Movement history can be retrieved via `GET …/movements`.
+
+All movement endpoints are nested under an inventory entry: `/api/stores/{store_id}/inventory/{inventory_id}/`.
 
 They require authentication and a valid `X-Org-Id` header, and validate that `store_id` belongs to the caller's organization.
 
@@ -930,6 +932,48 @@ Records an outgoing stock sale. Decrements the inventory entry's `quantity` by t
 
 **Errors:**
 - `400` — Insufficient stock (sale quantity exceeds `quantity` on the inventory entry).
+- `404` — Inventory entry not found.
+- `404` — Store not found in the current org.
+
+---
+
+### `GET /api/stores/{store_id}/inventory/{inventory_id}/movements`
+
+Returns the full stock-movement history for an inventory item, newest first. Includes both receipts and sales.
+
+**Auth:** Required — any org member  
+**Response** `200`
+
+```json
+[
+  {
+    "id": "movement-uuid",
+    "store_inventory_id": "entry-uuid",
+    "movement_type": "sale",
+    "quantity": 12,
+    "unit_cost": null,
+    "unit_price": "2.99",
+    "reference_number": "INV-2026-042",
+    "notes": "Weekly sale batch",
+    "performed_by_user_id": "user-uuid",
+    "created_at": "2026-03-31T14:05:00Z"
+  },
+  {
+    "id": "movement-uuid-2",
+    "store_inventory_id": "entry-uuid",
+    "movement_type": "receipt",
+    "quantity": 50,
+    "unit_cost": "1.25",
+    "unit_price": null,
+    "reference_number": "PO-2026-001",
+    "notes": "Spring restock from Fresh Farms",
+    "performed_by_user_id": "user-uuid",
+    "created_at": "2026-03-31T14:00:00Z"
+  }
+]
+```
+
+**Errors:**
 - `404` — Inventory entry not found.
 - `404` — Store not found in the current org.
 


### PR DESCRIPTION
Adds the missing movement history route and backing service function:

  GET /api/stores/{store_id}/inventory/{inventory_id}/movements
  → 200 list[MovementRead], newest first

Service: list_movements(db, inventory_id, store_id) validates inventory → store scope (NotFound on mismatch) then returns all InventoryMovement rows ordered by created_at DESC.

Also updates docs/api-reference.md with the new endpoint.
