### PR TITLE
feat: add analytics zone inventory summary endpoint

### DIFF
--- a/app/analytics/__init__.py
+++ b/app/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Analytics package — aggregate data endpoints for dashboards and heatmaps."""

--- a/app/analytics/routes.py
+++ b/app/analytics/routes.py
@@ -1,0 +1,7 @@
+"""Routes for analytics endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api/stores/{store_id}/analytics", tags=["analytics"])

--- a/app/analytics/routes.py
+++ b/app/analytics/routes.py
@@ -2,6 +2,31 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.models.store import Store
+from app.stores.deps import get_store_from_path
+from app.analytics.schemas import ZoneInventorySummaryResponse
+from app.analytics import service
 
 router = APIRouter(prefix="/api/stores/{store_id}/analytics", tags=["analytics"])
+
+
+@router.get(
+    "/zone-inventory-summary",
+    response_model=ZoneInventorySummaryResponse,
+)
+async def get_zone_inventory_summary(
+    store: Store = Depends(get_store_from_path),
+    db: AsyncSession = Depends(get_db),
+) -> ZoneInventorySummaryResponse:
+    """
+    Return per-zone inventory stock data for the store's active layout.
+
+    Powers the Inventory Heatmap view — each zone includes aggregate stock
+    counts, a health ratio, and a list of individual inventory items with
+    their current stock status.
+    """
+    return await service.get_zone_inventory_summary(db, store.id)

--- a/app/analytics/schemas.py
+++ b/app/analytics/schemas.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import uuid
+from decimal import Decimal
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
 # ── Shared cell schema ────────────────────────────────────────────────────────
 
@@ -40,7 +41,7 @@ class ZoneInventoryItem(BaseModel):
     category: str | None = None
     quantity: float
     low_stock_threshold: float | None = None
-    unit_price: str | None = None
+    unit_price: Decimal | None = None
     stock_status: StockStatus
 
 
@@ -57,6 +58,7 @@ class ZoneInventorySummary(BaseModel):
     out_of_stock_count: int = 0
     items: list[ZoneInventoryItem] = Field(default_factory=list)
 
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def health_ratio(self) -> float:
         """0.0 = all healthy, 1.0 = all items have stock issues.

--- a/app/analytics/schemas.py
+++ b/app/analytics/schemas.py
@@ -1,3 +1,99 @@
 """Pydantic schemas for analytics responses."""
 
 from __future__ import annotations
+
+import uuid
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+# ── Shared cell schema ────────────────────────────────────────────────────────
+
+
+class CellSchema(BaseModel):
+    """A single grid cell coordinate."""
+
+    row: int
+    col: int
+
+
+# ── Stock status enum ─────────────────────────────────────────────────────────
+
+
+class StockStatus(str, Enum):
+    """Stock health classification for an inventory item."""
+
+    OK = "ok"
+    LOW = "low"
+    OUT = "out"
+
+
+# ── Zone inventory summary ────────────────────────────────────────────────────
+
+
+class ZoneInventoryItem(BaseModel):
+    """A single inventory item within a zone, with stock health info."""
+
+    inventory_id: uuid.UUID
+    product_name: str
+    sku: str | None = None
+    category: str | None = None
+    quantity: int
+    low_stock_threshold: int | None = None
+    unit_price: str | None = None
+    stock_status: StockStatus
+
+
+class ZoneInventorySummary(BaseModel):
+    """Per-zone aggregate inventory data for the heatmap."""
+
+    zone_id: uuid.UUID
+    zone_name: str
+    zone_color: str
+    cells: list[CellSchema]
+    total_items: int = 0
+    total_quantity: int = 0
+    low_stock_count: int = 0
+    out_of_stock_count: int = 0
+    items: list[ZoneInventoryItem] = Field(default_factory=list)
+
+    @property
+    def health_ratio(self) -> float:
+        """0.0 = all healthy, 1.0 = all items have stock issues.
+
+        Used by the frontend to compute heatmap color intensity.
+        """
+        if self.total_items == 0:
+            return 0.0
+        return (self.low_stock_count + self.out_of_stock_count) / self.total_items
+
+
+class FixtureSummary(BaseModel):
+    """Minimal fixture info for rendering non-interactive heatmap cells."""
+
+    fixture_id: uuid.UUID
+    fixture_name: str
+    fixture_type: str
+    cells: list[CellSchema]
+
+
+class UnzonedSummary(BaseModel):
+    """Aggregate for inventory items not assigned to any zone."""
+
+    total_items: int = 0
+    total_quantity: int = 0
+    low_stock_count: int = 0
+    out_of_stock_count: int = 0
+
+
+class ZoneInventorySummaryResponse(BaseModel):
+    """Top-level response for the zone inventory summary endpoint."""
+
+    layout_id: uuid.UUID
+    layout_version: int
+    rows: int
+    cols: int
+    zones: list[ZoneInventorySummary]
+    fixtures: list[FixtureSummary]
+    unzoned_summary: UnzonedSummary

--- a/app/analytics/schemas.py
+++ b/app/analytics/schemas.py
@@ -1,0 +1,3 @@
+"""Pydantic schemas for analytics responses."""
+
+from __future__ import annotations

--- a/app/analytics/schemas.py
+++ b/app/analytics/schemas.py
@@ -7,7 +7,6 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
-
 # ── Shared cell schema ────────────────────────────────────────────────────────
 
 
@@ -39,8 +38,8 @@ class ZoneInventoryItem(BaseModel):
     product_name: str
     sku: str | None = None
     category: str | None = None
-    quantity: int
-    low_stock_threshold: int | None = None
+    quantity: float
+    low_stock_threshold: float | None = None
     unit_price: str | None = None
     stock_status: StockStatus
 
@@ -53,7 +52,7 @@ class ZoneInventorySummary(BaseModel):
     zone_color: str
     cells: list[CellSchema]
     total_items: int = 0
-    total_quantity: int = 0
+    total_quantity: float = 0
     low_stock_count: int = 0
     out_of_stock_count: int = 0
     items: list[ZoneInventoryItem] = Field(default_factory=list)
@@ -82,7 +81,7 @@ class UnzonedSummary(BaseModel):
     """Aggregate for inventory items not assigned to any zone."""
 
     total_items: int = 0
-    total_quantity: int = 0
+    total_quantity: float = 0
     low_stock_count: int = 0
     out_of_stock_count: int = 0
 

--- a/app/analytics/service.py
+++ b/app/analytics/service.py
@@ -10,7 +10,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.exceptions import NotFound
-from app.models.fixture import Fixture
 from app.models.inventory_placement import InventoryPlacement
 from app.models.layout_version import LayoutVersion
 from app.models.store_inventory import StoreInventory
@@ -120,7 +119,7 @@ async def get_zone_inventory_summary(
                     category=inv.product.category,
                     quantity=inv.quantity,
                     low_stock_threshold=inv.low_stock_threshold,
-                    unit_price=str(inv.unit_price) if inv.unit_price else None,
+                    unit_price=inv.unit_price,
                     stock_status=status,
                 )
             )

--- a/app/analytics/service.py
+++ b/app/analytics/service.py
@@ -26,7 +26,7 @@ from app.analytics.schemas import (
 )
 
 
-def _classify_stock(quantity: int, threshold: int | None) -> StockStatus:
+def _classify_stock(quantity: float, threshold: float | None) -> StockStatus:
     """Determine stock health status for a single inventory item."""
     if quantity <= 0:
         return StockStatus.OUT
@@ -102,7 +102,7 @@ async def get_zone_inventory_summary(
         zone_inv_items: list[ZoneInventoryItem] = []
         low_count = 0
         out_count = 0
-        total_qty = 0
+        total_qty: float = 0
 
         for inv in items:
             status = _classify_stock(inv.quantity, inv.low_stock_threshold)
@@ -143,8 +143,12 @@ async def get_zone_inventory_summary(
     fixture_summaries: list[FixtureSummary] = [
         FixtureSummary(
             fixture_id=f.id,
-            fixture_name=f.name,
-            fixture_type=f.fixture_type.value if hasattr(f.fixture_type, "value") else str(f.fixture_type),
+            fixture_name=f.name or f.fixture_type.value,
+            fixture_type=(
+                f.fixture_type.value
+                if hasattr(f.fixture_type, "value")
+                else str(f.fixture_type)
+            ),
             cells=[CellSchema(row=c["row"], col=c["col"]) for c in f.cells],
         )
         for f in layout.fixtures
@@ -153,7 +157,7 @@ async def get_zone_inventory_summary(
     # ── 6. Build unzoned summary ──────────────────────────────────────────
     unzoned_low = 0
     unzoned_out = 0
-    unzoned_qty = 0
+    unzoned_qty: float = 0
     for inv in unzoned_items:
         status = _classify_stock(inv.quantity, inv.low_stock_threshold)
         if status == StockStatus.LOW:

--- a/app/analytics/service.py
+++ b/app/analytics/service.py
@@ -1,0 +1,3 @@
+"""Service layer for analytics aggregate queries."""
+
+from __future__ import annotations

--- a/app/analytics/service.py
+++ b/app/analytics/service.py
@@ -1,3 +1,179 @@
 """Service layer for analytics aggregate queries."""
 
 from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.core.exceptions import NotFound
+from app.models.fixture import Fixture
+from app.models.inventory_placement import InventoryPlacement
+from app.models.layout_version import LayoutVersion
+from app.models.store_inventory import StoreInventory
+from app.models.zone import Zone
+from app.analytics.schemas import (
+    CellSchema,
+    FixtureSummary,
+    StockStatus,
+    UnzonedSummary,
+    ZoneInventoryItem,
+    ZoneInventorySummary,
+    ZoneInventorySummaryResponse,
+)
+
+
+def _classify_stock(quantity: int, threshold: int | None) -> StockStatus:
+    """Determine stock health status for a single inventory item."""
+    if quantity <= 0:
+        return StockStatus.OUT
+    if threshold is not None and quantity <= threshold:
+        return StockStatus.LOW
+    return StockStatus.OK
+
+
+async def get_zone_inventory_summary(
+    db: AsyncSession,
+    store_id: uuid.UUID,
+) -> ZoneInventorySummaryResponse:
+    """
+    Build the zone-level inventory heatmap data for a store.
+
+    Fetches the active layout, all zones/fixtures, and all inventory items
+    with their active placements in two queries. Returns aggregated per-zone
+    inventory statistics plus an unzoned summary.
+
+    Raises :class:`NotFound` if the store has no active layout version.
+    """
+    # ── 1. Get active layout with zones and fixtures ──────────────────────
+    layout_result = await db.execute(
+        select(LayoutVersion)
+        .where(
+            and_(
+                LayoutVersion.store_id == store_id,
+                LayoutVersion.is_active.is_(True),
+            )
+        )
+        .options(
+            selectinload(LayoutVersion.zones),
+            selectinload(LayoutVersion.fixtures),
+        )
+    )
+    layout = layout_result.scalar_one_or_none()
+    if layout is None:
+        raise NotFound(f"No active layout version found for store {store_id}")
+
+    # Build zone lookup: zone_id → Zone ORM object
+    zone_map: dict[uuid.UUID, Zone] = {z.id: z for z in layout.zones}
+
+    # ── 2. Get all inventory items with their active placements ───────────
+    # LEFT JOIN so we also capture items with no active placement (unzoned).
+    inv_result = await db.execute(
+        select(StoreInventory, InventoryPlacement.zone_id)
+        .outerjoin(
+            InventoryPlacement,
+            and_(
+                InventoryPlacement.store_inventory_id == StoreInventory.id,
+                InventoryPlacement.ended_at.is_(None),
+            ),
+        )
+        .where(StoreInventory.store_id == store_id)
+        .options(selectinload(StoreInventory.product))
+    )
+
+    # ── 3. Group items by zone ────────────────────────────────────────────
+    zoned_items: dict[uuid.UUID, list[StoreInventory]] = defaultdict(list)
+    unzoned_items: list[StoreInventory] = []
+
+    for inv, zone_id in inv_result.all():
+        if zone_id and zone_id in zone_map:
+            zoned_items[zone_id].append(inv)
+        else:
+            unzoned_items.append(inv)
+
+    # ── 4. Build per-zone summaries ───────────────────────────────────────
+    zone_summaries: list[ZoneInventorySummary] = []
+
+    for zone in layout.zones:
+        items = zoned_items.get(zone.id, [])
+        zone_inv_items: list[ZoneInventoryItem] = []
+        low_count = 0
+        out_count = 0
+        total_qty = 0
+
+        for inv in items:
+            status = _classify_stock(inv.quantity, inv.low_stock_threshold)
+            if status == StockStatus.LOW:
+                low_count += 1
+            elif status == StockStatus.OUT:
+                out_count += 1
+            total_qty += inv.quantity
+
+            zone_inv_items.append(
+                ZoneInventoryItem(
+                    inventory_id=inv.id,
+                    product_name=inv.product.name,
+                    sku=inv.product.sku,
+                    category=inv.product.category,
+                    quantity=inv.quantity,
+                    low_stock_threshold=inv.low_stock_threshold,
+                    unit_price=str(inv.unit_price) if inv.unit_price else None,
+                    stock_status=status,
+                )
+            )
+
+        zone_summaries.append(
+            ZoneInventorySummary(
+                zone_id=zone.id,
+                zone_name=zone.name,
+                zone_color=zone.color,
+                cells=[CellSchema(row=c["row"], col=c["col"]) for c in zone.cells],
+                total_items=len(items),
+                total_quantity=total_qty,
+                low_stock_count=low_count,
+                out_of_stock_count=out_count,
+                items=zone_inv_items,
+            )
+        )
+
+    # ── 5. Build fixture summaries ────────────────────────────────────────
+    fixture_summaries: list[FixtureSummary] = [
+        FixtureSummary(
+            fixture_id=f.id,
+            fixture_name=f.name,
+            fixture_type=f.fixture_type.value if hasattr(f.fixture_type, "value") else str(f.fixture_type),
+            cells=[CellSchema(row=c["row"], col=c["col"]) for c in f.cells],
+        )
+        for f in layout.fixtures
+    ]
+
+    # ── 6. Build unzoned summary ──────────────────────────────────────────
+    unzoned_low = 0
+    unzoned_out = 0
+    unzoned_qty = 0
+    for inv in unzoned_items:
+        status = _classify_stock(inv.quantity, inv.low_stock_threshold)
+        if status == StockStatus.LOW:
+            unzoned_low += 1
+        elif status == StockStatus.OUT:
+            unzoned_out += 1
+        unzoned_qty += inv.quantity
+
+    # ── 7. Assemble response ──────────────────────────────────────────────
+    return ZoneInventorySummaryResponse(
+        layout_id=layout.id,
+        layout_version=layout.version_number,
+        rows=layout.rows,
+        cols=layout.cols,
+        zones=zone_summaries,
+        fixtures=fixture_summaries,
+        unzoned_summary=UnzonedSummary(
+            total_items=len(unzoned_items),
+            total_quantity=unzoned_qty,
+            low_stock_count=unzoned_low,
+            out_of_stock_count=unzoned_out,
+        ),
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from app.fixtures.routes import router as fixtures_router
 from app.stores.routes import router as stores_router
 from app.suppliers.routes import router as suppliers_router
 from app.store_inventory.routes import router as store_inventory_router
+from app.analytics.routes import router as analytics_router
 
 # ── Structured JSON logging to stdout → Docker → CloudWatch ──
 handler = logging.StreamHandler(sys.stdout)
@@ -91,6 +92,7 @@ def create_app() -> FastAPI:
     app.include_router(layouts_router)
     app.include_router(zones_router)
     app.include_router(fixtures_router)
+    app.include_router(analytics_router)
 
     return app
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,6 +23,7 @@ Complete reference for every endpoint in the EasyInventory API. All routes retur
 - [Inventory Placements](#inventory-placements)
 - [Layout Versions](#layout-versions)
 - [Zones](#zones)
+- [Analytics](#analytics)
 - [Admin: Organizations](#admin-organizations)
 - [Admin: Users](#admin-users)
 - [Invite Flow Details](#invite-flow-details)
@@ -1377,6 +1378,83 @@ Deletes a zone.
 **Errors:**
 - `403` — Caller is not `ORG_OWNER` or `ORG_ADMIN`.
 - `404` — Zone, layout version, or store not found in the current org.
+
+---
+
+## Analytics
+
+Aggregate data endpoints for dashboards and heatmaps. Analytics endpoints read across multiple domain models (layouts, zones, fixtures, inventory, placements) and return pre-computed summaries.
+
+### `GET /api/stores/{store_id}/analytics/zone-inventory-summary`
+
+Returns per-zone inventory stock data for the store's active layout. Powers the **Inventory Heatmap** view — each zone includes aggregate stock counts, a health ratio, and a list of individual inventory items with their current stock status.
+
+**Auth:** Required — any org member  
+**Path Params:**
+
+| Param | Type | Description |
+|---|---|---|
+| `store_id` | UUID | The store to query |
+
+**Response** `200`
+
+```json
+{
+  "layout_id": "uuid",
+  "layout_version": 1,
+  "rows": 10,
+  "cols": 8,
+  "zones": [
+    {
+      "zone_id": "uuid",
+      "zone_name": "Zone A",
+      "zone_color": "#4A90D9",
+      "cells": [{"row": 0, "col": 0}, {"row": 0, "col": 1}],
+      "total_items": 5,
+      "total_quantity": 120,
+      "low_stock_count": 1,
+      "out_of_stock_count": 0,
+      "items": [
+        {
+          "inventory_id": "uuid",
+          "product_name": "Widget A",
+          "sku": "WA-001",
+          "category": "Widgets",
+          "quantity": 25,
+          "low_stock_threshold": 10,
+          "unit_price": "4.9900",
+          "stock_status": "ok"
+        }
+      ]
+    }
+  ],
+  "fixtures": [
+    {
+      "fixture_id": "uuid",
+      "fixture_name": "North Exit",
+      "fixture_type": "DOOR",
+      "cells": [{"row": 0, "col": 3}]
+    }
+  ],
+  "unzoned_summary": {
+    "total_items": 2,
+    "total_quantity": 50,
+    "low_stock_count": 1,
+    "out_of_stock_count": 0
+  }
+}
+```
+
+**Stock status values:**
+
+| Value | Meaning |
+|---|---|
+| `ok` | Quantity is above the low-stock threshold (or no threshold set) |
+| `low` | Quantity is at or below the low-stock threshold |
+| `out` | Quantity is zero or negative |
+
+**Errors:**
+- `404` — Store not found in the current org, or no active layout version exists for the store.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,11 @@ easyinventory-api/
 │   │   ├── schemas.py           #   StoreInventory schemas + MovementRead / RecordReceiptRequest / RecordSaleRequest + AssignZoneRequest / PlacementRead
 │   │   └── service.py           #   Inventory data access + record_receipt / record_sale + assign_zone / get_placement_history / remove_from_zone
 │   │
+│   ├── analytics/               # Analytics domain (cross-model aggregations)
+│   │   ├── routes.py            #   GET /api/stores/{store_id}/analytics/zone-inventory-summary
+│   │   ├── schemas.py           #   ZoneInventorySummaryResponse, ZoneInventorySummary, FixtureSummary, UnzonedSummary, etc.
+│   │   └── service.py           #   Aggregate queries joining layouts, zones, fixtures, inventory, and placements
+│   │
 │   ├── suppliers/               # Suppliers domain
 │   │   ├── routes.py            #   Supplier CRUD endpoints
 │   │   ├── schemas.py           #   Supplier Pydantic schemas

--- a/tests/test_analytics_routes.py
+++ b/tests/test_analytics_routes.py
@@ -51,7 +51,9 @@ class TestZoneInventorySummaryRoute:
         """Endpoint returns 200 when service succeeds."""
         with (
             patch("app.analytics.routes.get_store_from_path") as mock_store_dep,
-            patch("app.analytics.routes.service.get_zone_inventory_summary") as mock_svc,
+            patch(
+                "app.analytics.routes.service.get_zone_inventory_summary"
+            ) as mock_svc,
             patch("app.auth.deps.get_current_user"),
             patch("app.orgs.deps.get_current_org_membership"),
         ):

--- a/tests/test_analytics_routes.py
+++ b/tests/test_analytics_routes.py
@@ -3,30 +3,20 @@
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app.auth.deps import get_current_user
+from app.core.database import get_db
 from app.main import create_app
+from app.orgs.deps import get_current_org_membership
+from app.stores.deps import get_store_from_path
 from app.analytics.schemas import (
-    FixtureSummary,
     UnzonedSummary,
     ZoneInventorySummaryResponse,
 )
-
-
-@pytest.fixture
-def app():
-    return create_app()
-
-
-@pytest.fixture
-async def client(app):
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        yield ac
-
 
 STORE_ID = str(uuid.uuid4())
 MOCK_RESPONSE = ZoneInventorySummaryResponse(
@@ -45,27 +35,55 @@ MOCK_RESPONSE = ZoneInventorySummaryResponse(
 )
 
 
+@pytest.fixture
+def app():
+    application = create_app()
+
+    mock_store = MagicMock()
+    mock_store.id = uuid.UUID(STORE_ID)
+
+    application.dependency_overrides[get_current_user] = lambda: MagicMock()
+    application.dependency_overrides[get_current_org_membership] = lambda: MagicMock()
+    application.dependency_overrides[get_store_from_path] = lambda: mock_store
+    application.dependency_overrides[get_db] = lambda: AsyncMock()
+
+    yield application
+
+    application.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
 class TestZoneInventorySummaryRoute:
     @pytest.mark.asyncio
     async def test_returns_200_with_valid_data(self, client):
         """Endpoint returns 200 when service succeeds."""
-        with (
-            patch("app.analytics.routes.get_store_from_path") as mock_store_dep,
-            patch(
-                "app.analytics.routes.service.get_zone_inventory_summary"
-            ) as mock_svc,
-            patch("app.auth.deps.get_current_user"),
-            patch("app.orgs.deps.get_current_org_membership"),
-        ):
-            mock_store = AsyncMock()
-            mock_store.id = uuid.UUID(STORE_ID)
-            mock_store_dep.return_value = mock_store
+        with patch(
+            "app.analytics.routes.service.get_zone_inventory_summary"
+        ) as mock_svc:
             mock_svc.return_value = MOCK_RESPONSE
 
             response = await client.get(
                 f"/api/stores/{STORE_ID}/analytics/zone-inventory-summary"
             )
 
-            # Note: In a real integration test the auth deps would need proper
-            # overrides. This test verifies route wiring and serialization.
-            assert response.status_code in (200, 403, 401)
+            assert response.status_code == 200
+            assert response.json() == {
+                "layout_id": str(MOCK_RESPONSE.layout_id),
+                "layout_version": MOCK_RESPONSE.layout_version,
+                "rows": MOCK_RESPONSE.rows,
+                "cols": MOCK_RESPONSE.cols,
+                "zones": [],
+                "fixtures": [],
+                "unzoned_summary": {
+                    "total_items": MOCK_RESPONSE.unzoned_summary.total_items,
+                    "total_quantity": MOCK_RESPONSE.unzoned_summary.total_quantity,
+                    "low_stock_count": MOCK_RESPONSE.unzoned_summary.low_stock_count,
+                    "out_of_stock_count": MOCK_RESPONSE.unzoned_summary.out_of_stock_count,
+                },
+            }

--- a/tests/test_analytics_routes.py
+++ b/tests/test_analytics_routes.py
@@ -1,0 +1,69 @@
+"""Route-level tests for analytics endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import create_app
+from app.analytics.schemas import (
+    FixtureSummary,
+    UnzonedSummary,
+    ZoneInventorySummaryResponse,
+)
+
+
+@pytest.fixture
+def app():
+    return create_app()
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+STORE_ID = str(uuid.uuid4())
+MOCK_RESPONSE = ZoneInventorySummaryResponse(
+    layout_id=uuid.uuid4(),
+    layout_version=1,
+    rows=10,
+    cols=8,
+    zones=[],
+    fixtures=[],
+    unzoned_summary=UnzonedSummary(
+        total_items=0,
+        total_quantity=0,
+        low_stock_count=0,
+        out_of_stock_count=0,
+    ),
+)
+
+
+class TestZoneInventorySummaryRoute:
+    @pytest.mark.asyncio
+    async def test_returns_200_with_valid_data(self, client):
+        """Endpoint returns 200 when service succeeds."""
+        with (
+            patch("app.analytics.routes.get_store_from_path") as mock_store_dep,
+            patch("app.analytics.routes.service.get_zone_inventory_summary") as mock_svc,
+            patch("app.auth.deps.get_current_user"),
+            patch("app.orgs.deps.get_current_org_membership"),
+        ):
+            mock_store = AsyncMock()
+            mock_store.id = uuid.UUID(STORE_ID)
+            mock_store_dep.return_value = mock_store
+            mock_svc.return_value = MOCK_RESPONSE
+
+            response = await client.get(
+                f"/api/stores/{STORE_ID}/analytics/zone-inventory-summary"
+            )
+
+            # Note: In a real integration test the auth deps would need proper
+            # overrides. This test verifies route wiring and serialization.
+            assert response.status_code in (200, 403, 401)

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -1,0 +1,55 @@
+"""Unit tests for analytics service — zone inventory summary."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.analytics.schemas import StockStatus
+from app.analytics.service import _classify_stock, get_zone_inventory_summary
+
+
+# ── _classify_stock tests ─────────────────────────────────────────────────────
+
+
+class TestClassifyStock:
+    def test_out_of_stock_zero(self):
+        assert _classify_stock(0, 10) == StockStatus.OUT
+
+    def test_out_of_stock_negative(self):
+        assert _classify_stock(-1, 10) == StockStatus.OUT
+
+    def test_low_stock_at_threshold(self):
+        assert _classify_stock(5, 5) == StockStatus.LOW
+
+    def test_low_stock_below_threshold(self):
+        assert _classify_stock(3, 5) == StockStatus.LOW
+
+    def test_ok_above_threshold(self):
+        assert _classify_stock(10, 5) == StockStatus.OK
+
+    def test_ok_no_threshold(self):
+        assert _classify_stock(10, None) == StockStatus.OK
+
+    def test_zero_no_threshold(self):
+        assert _classify_stock(0, None) == StockStatus.OUT
+
+
+# ── get_zone_inventory_summary tests ──────────────────────────────────────────
+
+
+class TestGetZoneInventorySummary:
+    @pytest.mark.asyncio
+    async def test_raises_not_found_when_no_active_layout(self):
+        """Should raise NotFound when the store has no active layout."""
+        db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        db.execute.return_value = mock_result
+
+        from app.core.exceptions import NotFound
+
+        with pytest.raises(NotFound):
+            await get_zone_inventory_summary(db, uuid.uuid4())

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -10,7 +10,6 @@ import pytest
 from app.analytics.schemas import StockStatus
 from app.analytics.service import _classify_stock, get_zone_inventory_summary
 
-
 # ── _classify_stock tests ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What
Adds a new `analytics` domain module with a **Zone Inventory Summary** endpoint (`GET /api/stores/{store_id}/analytics/zone-inventory-summary`). Returns per-zone aggregate stock data for the store's active layout, including item counts, stock health classification, fixture positions, and an unzoned item summary — all in a single API call.

## Why
Powers the **Inventory Heatmap** page on the frontend. This data must be aggregated across multiple domain models (layouts, zones, fixtures, inventory, placements), so it lives in a dedicated `analytics` module rather than bloating an existing one. The module is designed to accommodate future metric endpoints (sales velocity, turnover, etc.).

## How to test
1. Ensure a store has an active layout with zones, fixtures, and inventory placements (the seed script covers this).
2. `GET /api/stores/{store_id}/analytics/zone-inventory-summary` — verify the response includes `zones` with per-zone `total_items`, `total_quantity`, `low_stock_count`, `out_of_stock_count`, and `items` arrays, plus `fixtures` and `unzoned_summary`.
3. Verify a store with no active layout returns `404`.
4. Run `make test` and `make lint` to confirm all checks pass.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes (black + mypy)
- [x] No hardcoded secrets or credentials
- [x] New env vars added to .env.example
- [x] README updated if needed

